### PR TITLE
changed old contact address in app info

### DIFF
--- a/ui/narrative/methods/annotate_contigset/display.yaml
+++ b/ui/narrative/methods/annotate_contigset/display.yaml
@@ -279,5 +279,7 @@ description : |
     For more information on the steps of the default RAStk pipeline please refer to our publication on this (publication forthcoming). For more detailed tutorial information and to explore the additional functionality of RASTtk not currently available in the Narrative interface please refer to <a href="http://tutorial.theseed.org">http://tutorial.theseed.org.</a></p>
     
     <p><strong>Team members who developed & deployed algorithm in KBase:</strong>
-    Thomas Brettin, James Davis, Terry Disz, Robert Edwards, Chris Henry, Gary Olsen, Robert Olson, Ross Overbeek, Bruce Parrello, Gordon Pusch, Roman Sutormin, Fangfang Xia. For questions, <a href="mailto:help@kbase.us">e-mail help@kbase.us</a></p>
+    Thomas Brettin, James Davis, Terry Disz, Robert Edwards, Chris Henry, Gary Olsen, Robert Olson, Ross Overbeek, Bruce Parrello, Gordon Pusch, Roman Sutormin, Fangfang Xia.
+    Questions? Suggestions? Bug reports? Please <a href="http://kbase.us/contact-us/">contact us</a> and include the app name and error message (if any).
+</p>
 


### PR DESCRIPTION
help@kbase -> http://kbase.us/contact-us/

not sure why i have to do this again! the thing that's weird is that the old text with help@kbase.us shows up in the "i" info popup you can access from an annotate microbial contigs app cell, but if you go to the app detail page (https://narrative.kbase.us/#catalog/apps/RAST_SDK/annotate_contigset/release) you see the updated text! how can those be different? @msneddon @briehl