### PR TITLE
[WIP] make /tmp a symlink in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,9 @@ WORKDIR /kb/module
 
 RUN make
 
+# try to force tmp files to be written to right spot
+RUN rm -rf /tmp && ln -s /kb/module/work/tmp /tmp
+
 ENTRYPOINT [ "./scripts/entrypoint.sh" ]
 
 CMD [ ]


### PR DESCRIPTION
Please do not merge yet, this is untested.

The genome annotation jobs write lots of output hardcoded to /tmp, which can fill the filesystem for nodes with a modest sized /var/lib/docker.  Rather than try to untangle what writes where, just try to symlink /tmp to /kb/module/work/tmp, so that the jobs write to the large scratch filesystem.