### PR TITLE
TASK-1175: Convert RAST_SDK to use refs & ref paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,12 @@ MAINTAINER KBase Developer
 # any required dependencies for your module.
 
 # RUN apt-get update
-RUN cpanm -i Config::IniFiles
-RUN cpanm -i Config::IniFiles
-RUN cpanm -i UUID::Random
-RUN cpanm -i HTML::SimpleLinkExtor
-RUN cpanm -i WWW::Mechanize --force
-RUN cpanm -i MIME::Base64
-RUN apt-get -y install nano
+RUN cpanm -i Config::IniFiles && \
+    cpanm -i UUID::Random && \
+    cpanm -i HTML::SimpleLinkExtor && \
+    cpanm -i WWW::Mechanize --force && \
+    cpanm -i MIME::Base64 && \
+    apt-get -y install nano
 
 ADD ./bootstrap bootstrap
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 ### OVERVIEW
 This module wraps the RAST annotation pipeline for KBase.
 
+### Version 0.0.9
+__Changes__
+- UI now passes resolved references rather than object names
+- Use reference chains to access assemblies from genome objects
+
 ### Version 0.0.8
 __Changes__
 - Added phispy dependencies

--- a/kbase.yml
+++ b/kbase.yml
@@ -10,10 +10,10 @@ service-language:
     perl
 
 module-version:
-    0.0.8
+    0.0.9
 
 owners:
-    [chenry,scanon,olson]
+    [chenry,scanon,olson,jjeffryes]
 
 data-version:
     0.2

--- a/lib/Bio/KBase/kbaseenv.pm
+++ b/lib/Bio/KBase/kbaseenv.pm
@@ -147,8 +147,13 @@ sub list_objects {
 }
 
 sub get_object_info {
-	my ($argone,$argtwo) = @_;
-	return Bio::KBase::kbaseenv::ws_client()->get_object_info($argone,$argtwo);
+	my ($argone,$argtwo,$argthree) = @_;
+	my $params = {
+		objects => $argone,
+		includeMetadata => $argtwo,
+		ignoreErrors => $argthree
+	};
+	return Bio::KBase::kbaseenv::ws_client()->get_object_info3($params)->{infos};
 }
 
 sub administer {

--- a/lib/Bio/KBase/kbaseenv.pm
+++ b/lib/Bio/KBase/kbaseenv.pm
@@ -199,23 +199,22 @@ sub save_objects {
 	return $output;
 }
 
-sub configure_ws_id {
-	my ($ws,$id,$version) = @_;
-	my $input = {};
- 	if ($ws =~ m/^\d+$/) {
- 		$input->{wsid} = $ws;
-	} else {
-		$input->{workspace} = $ws;
+sub buildref {
+	my ($ws, $id, $version) = @_;
+	#Check if the ID is a ref or ref_path with a version
+	if ($id =~ m/^(([^\/]+)\/([^\/]+)\/(\d+);?)+$/) {
+		return $id;
 	}
-	if ($id =~ m/^\d+$/) {
-		$input->{objid} = $id;
-	} else {
-		$input->{name} = $id;
+	#Check if the ID contains lacks "/" which indicates that it is not a ref
+	elsif ($id !~ m/\//) {
+		#Removing any "/" that may appear at the end of the ws
+		$ws =~ s/\/$//;
+		$id = $ws . "/" . $id;
 	}
-	if (defined($version)) {
-		$input->{ver} = $version;
+	if (defined $version) {
+		return $id . "/" . $version;
 	}
-	return $input;
+	return $id;
 }
 
 sub initialize_call {

--- a/lib/RAST_SDK/RAST_SDKImpl.pm
+++ b/lib/RAST_SDK/RAST_SDKImpl.pm
@@ -227,7 +227,7 @@ sub annotate {
 		}
 	}
 	
-  	#my $gaserv = Bio::KBase::GenomeAnnotation::GenomeAnnotationImpl->new();
+  	my $gaserv = Bio::KBase::GenomeAnnotation::GenomeAnnotationImpl->new();
   	my $workflow = {stages => []};
 	my $extragenecalls = "";
 	if (defined($parameters->{call_features_rRNA_SEED}) && $parameters->{call_features_rRNA_SEED} == 1)	{
@@ -511,9 +511,8 @@ sub annotate {
 			}
 		}
 	}
-	#eval {
-		#$genome = $gaserv->run_pipeline($inputgenome, $workflow);
-	#};
+	# Runs, the annotation, comment out if you dont have the reference files
+	$genome = $gaserv->run_pipeline($inputgenome, $workflow);
 
 	delete $genome->{contigs};
 	delete $genome->{feature_creation_event};

--- a/lib/RAST_SDK/RAST_SDKImpl.pm
+++ b/lib/RAST_SDK/RAST_SDKImpl.pm
@@ -186,7 +186,7 @@ sub annotate {
 		    } elsif (defined($inputgenome->{assembly_ref})) {
 			$contigref = $inputgenome->{assembly_ref};
 		    }
-			$contigobj = $self->util_get_contigs(undef,$contigref)
+			$contigobj = $self->util_get_contigs(undef,$inputgenome->{_reference}.";".$contigref)
 		}
 		$parameters->{genetic_code} = $inputgenome->{genetic_code};
 		$parameters->{domain} = $inputgenome->{domain};

--- a/test/full_shewanella_test.pl
+++ b/test/full_shewanella_test.pl
@@ -145,7 +145,7 @@ sub reannotate_genome {
     return $impl->annotate_genome($params);
     #return make_impl_call("RAST_SDK.annotate_genome", $params);
 }
-die;
+
 my $diff_count = 0;
 lives_ok {
     print("Loading assembly to WS\n");

--- a/test/full_shewanella_test.pl
+++ b/test/full_shewanella_test.pl
@@ -1,6 +1,7 @@
 use strict;
 use Data::Dumper;
 use Test::More;
+use Test::Exception;
 use Config::Simple;
 use Time::HiRes qw(time);
 use Workspace::WorkspaceClient;
@@ -8,6 +9,7 @@ use JSON;
 use File::Copy;
 use AssemblyUtil::AssemblyUtilClient;
 use Storable qw(dclone);
+use RAST_SDK::RAST_SDKImpl
 
 local $| = 1;
 my $token = $ENV{'KB_AUTH_TOKEN'};
@@ -16,6 +18,10 @@ my $config = new Config::Simple($config_file)->get_block('RAST_SDK');
 my $ws_url = $config->{"workspace-url"};
 my $ws_name = undef;
 my $ws_client = new Workspace::WorkspaceClient($ws_url,token => $token);
+my $auth_token = Bio::KBase::AuthToken->new(token => $token, ignore_authrc => 1);
+my $ctx = LocalCallContext->new($token, $auth_token->user_id);
+$RAST_SDK::RAST_SDKServer::CallContext = $ctx;
+my $impl = new RAST_SDK::RAST_SDKImpl();
 
 sub get_ws_name {
     if (!defined($ws_name)) {
@@ -67,12 +73,13 @@ sub prepare_assembly {
     copy $fasta_data_path, $fasta_temp_path;
     my $call_back_url = $ENV{ SDK_CALLBACK_URL };
     my $au = new AssemblyUtil::AssemblyUtilClient($call_back_url);
-    $au->save_assembly_from_fasta({
+    my $ret = $au->save_assembly_from_fasta({
         file => {path => $fasta_temp_path},
         workspace_name => get_ws_name(),
         assembly_name => $assembly_obj_name
     });
     unlink($fasta_temp_path);
+    return $ret;
 }
 
 sub load_genome_from_json {
@@ -100,20 +107,21 @@ sub load_genome_from_json {
 
 sub save_genome_to_ws {
     my($genome_obj,$genome_obj_name) = @_;
-    my $ret = $ws_client->save_objects({workspace=>get_ws_name(),objects=>[{data=>$genome_obj,
+    my $info = $ws_client->save_objects({workspace=>get_ws_name(),objects=>[{data=>$genome_obj,
             type=>"KBaseGenomes.Genome", name=>$genome_obj_name}]})->[0];
+    return $info->[6]."/".$info->[0]."/".$info->[4];
 }
 
 sub prepare_genome {
     my($assembly_obj_name,$genome_obj_name,$input_json_file) = @_;
     my $genome_obj = load_genome_from_json($assembly_obj_name,$input_json_file);
-    save_genome_to_ws($genome_obj, $genome_obj_name);
-    return $genome_obj;
+    my $genome_upa = save_genome_to_ws($genome_obj, $genome_obj_name);
+    return ($genome_obj, $genome_upa);
 }
 
 sub reannotate_genome {
-    my($genome_obj_name) = @_;
-    my $params={"input_genome"=>$genome_obj_name,
+    my($genome_obj_name, $genome_upa) = @_;
+    my $params={"input_genome"=>$genome_upa,
              "call_features_rRNA_SEED"=>'0',
              "call_features_tRNA_trnascan"=>'0',
              "call_selenoproteins"=>'0',
@@ -134,17 +142,19 @@ sub reannotate_genome {
              "output_genome"=>$genome_obj_name,
              "workspace"=>get_ws_name()
            };
-    return make_impl_call("RAST_SDK.annotate_genome", $params);
+    return $impl->annotate_genome($params);
+    #return make_impl_call("RAST_SDK.annotate_genome", $params);
 }
-
-eval {
+die;
+my $diff_count = 0;
+lives_ok {
     print("Loading assembly to WS\n");
     my $assembly_obj_name = "assembly.1";
     prepare_assembly($assembly_obj_name);
     my $genome_obj_name = "genome.1";
     print("Loading genome to WS\n");
     my $genome_json_path = "/kb/module/test/data/shewy_genome.json";
-    my $orig_genome = prepare_genome($assembly_obj_name, $genome_obj_name, $genome_json_path);
+    my ($orig_genome, $genome_upa) = prepare_genome($assembly_obj_name, $genome_obj_name, $genome_json_path);
     my $orig_funcs = {};
     for (my $i=0; $i < @{$orig_genome->{features}}; $i++) {
         my $ftr = $orig_genome->{features}->[$i];
@@ -158,7 +168,7 @@ eval {
     print $fh encode_json($orig_funcs);
     close $fh;
     print("Running RAST annotation\n");
-    my $ret = reannotate_genome($genome_obj_name);
+    my $ret = reannotate_genome($genome_obj_name, $genome_upa);
     my $report_ref = $ret->{report_ref};
     my $report_obj = $ws_client->get_objects([{ref=>$report_ref}])->[0]->{data};
     my $report_json = encode_json($report_obj);
@@ -170,7 +180,6 @@ eval {
     open my $fh, ">", "/kb/module/work/tmp/shewy_genome_reannot.json";
     print $fh encode_json($genome_obj);
     close $fh;
-    my $diff_count = 0;
     for (my $i=0; $i < @{$genome_obj->{features}}; $i++) {
         my $ftr = $genome_obj->{features}->[$i];
         my $func = $ftr->{function};
@@ -182,10 +191,10 @@ eval {
             $diff_count++;
         }
     }
-    print "Number of features with changed function: " . $diff_count . "\n";
-    ok($diff_count > 1000, "Number of updated features (" . $diff_count . ")");
-    done_testing(1);
-};
+    } "Pipeline Runs";
+print "Number of features with changed function: " . $diff_count . "\n";
+ok($diff_count > 1000, "Number of updated features (" . $diff_count . ")");
+done_testing(2);
 
 my $err = undef;
 if ($@) {

--- a/ui/narrative/methods/annotate_contigset/spec.json
+++ b/ui/narrative/methods/annotate_contigset/spec.json
@@ -280,7 +280,8 @@
       "input_mapping" : [
         {
           "input_parameter": "input_contigset",
-          "target_property": "input_contigset"
+          "target_property": "input_contigset",
+          "target_type_transform": "resolved-ref"
         },
         {
           "input_parameter": "scientific_name",

--- a/ui/narrative/methods/annotate_plant_transcripts/spec.json
+++ b/ui/narrative/methods/annotate_plant_transcripts/spec.json
@@ -39,7 +39,8 @@
       "input_mapping" : [
         {
           "input_parameter": "input_genome",
-          "target_property": "input_genome"
+          "target_property": "input_genome",
+          "target_type_transform": "resolved-ref"
         },
         {
           "input_parameter": "output_genome",

--- a/ui/narrative/methods/reannotate_microbial_genome/spec.json
+++ b/ui/narrative/methods/reannotate_microbial_genome/spec.json
@@ -239,7 +239,8 @@
       "input_mapping" : [
         {
           "input_parameter": "input_genome",
-          "target_property": "input_genome"
+          "target_property": "input_genome",
+          "target_type_transform": "resolved-ref"
         },
         {
           "input_parameter": "call_features_rRNA_SEED",

--- a/ui/narrative/methods/reannotate_microbial_genomes/spec.json
+++ b/ui/narrative/methods/reannotate_microbial_genomes/spec.json
@@ -238,7 +238,8 @@
       "input_mapping" : [
         {
           "input_parameter": "input_genomes",
-          "target_property": "input_genomes"
+          "target_property": "input_genomes",
+          "target_type_transform": "resolved-ref"
         },
         {
           "input_parameter": "genome_text",


### PR DESCRIPTION
Updated tests to use auth2 & full object references
Updated UI to use resolved-refs
Updated Impl to use reference chains to access assemblies from genomes
Impl is back compatible to use of original object names
Was not able to test annotation pipeline itself due to dependency on large reference files