### PR TITLE
SCT-721

### DIFF
--- a/RAST_SDK.spec
+++ b/RAST_SDK.spec
@@ -48,7 +48,6 @@ module RAST_SDK {
 	    bool kmer_v1_parameters;
 	    bool annotate_proteins_similarity;
 	    bool resolve_overlapping_features;
-	    bool find_close_neighbors;
 	    bool call_features_prophage_phispy;
 	    bool retain_old_anno_for_hypotheticals;
 	} AnnotateGenomeParams;
@@ -94,7 +93,6 @@ module RAST_SDK {
 	    bool kmer_v1_parameters;
 	    bool annotate_proteins_similarity;
 	    bool resolve_overlapping_features;
-	    bool find_close_neighbors;
 	    bool call_features_prophage_phispy;
 	    bool retain_old_anno_for_hypotheticals;
 	} AnnotateGenomesParams;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 ### OVERVIEW
 This module wraps the RAST annotation pipeline for KBase.
 
+### Version 0.0.12
+__Changes__
+- Remove find close neighbors option. Users should use genome tree instead.
+
 ### Version 0.0.11
 __Changes__
 - Save genomes though the GenomeFileUtils

--- a/kbase.yml
+++ b/kbase.yml
@@ -10,7 +10,7 @@ service-language:
     perl
 
 module-version:
-    0.0.11
+    0.0.12
 
 owners:
     [chenry,scanon,olson,jjeffryes,umaganapathyswork]

--- a/lib/RAST_SDK/RAST_SDKClient.pm
+++ b/lib/RAST_SDK/RAST_SDKClient.pm
@@ -146,7 +146,6 @@ AnnotateGenomeParams is a reference to a hash where the following keys are defin
 	kmer_v1_parameters has a value which is a RAST_SDK.bool
 	annotate_proteins_similarity has a value which is a RAST_SDK.bool
 	resolve_overlapping_features has a value which is a RAST_SDK.bool
-	find_close_neighbors has a value which is a RAST_SDK.bool
 	call_features_prophage_phispy has a value which is a RAST_SDK.bool
 	retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 genome_id is a string
@@ -191,7 +190,6 @@ AnnotateGenomeParams is a reference to a hash where the following keys are defin
 	kmer_v1_parameters has a value which is a RAST_SDK.bool
 	annotate_proteins_similarity has a value which is a RAST_SDK.bool
 	resolve_overlapping_features has a value which is a RAST_SDK.bool
-	find_close_neighbors has a value which is a RAST_SDK.bool
 	call_features_prophage_phispy has a value which is a RAST_SDK.bool
 	retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 genome_id is a string
@@ -296,7 +294,6 @@ AnnotateGenomesParams is a reference to a hash where the following keys are defi
 	kmer_v1_parameters has a value which is a RAST_SDK.bool
 	annotate_proteins_similarity has a value which is a RAST_SDK.bool
 	resolve_overlapping_features has a value which is a RAST_SDK.bool
-	find_close_neighbors has a value which is a RAST_SDK.bool
 	call_features_prophage_phispy has a value which is a RAST_SDK.bool
 	retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 GenomeParams is a reference to a hash where the following keys are defined:
@@ -342,7 +339,6 @@ AnnotateGenomesParams is a reference to a hash where the following keys are defi
 	kmer_v1_parameters has a value which is a RAST_SDK.bool
 	annotate_proteins_similarity has a value which is a RAST_SDK.bool
 	resolve_overlapping_features has a value which is a RAST_SDK.bool
-	find_close_neighbors has a value which is a RAST_SDK.bool
 	call_features_prophage_phispy has a value which is a RAST_SDK.bool
 	retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 GenomeParams is a reference to a hash where the following keys are defined:
@@ -667,7 +663,6 @@ annotate_proteins_kmer_v2 has a value which is a RAST_SDK.bool
 kmer_v1_parameters has a value which is a RAST_SDK.bool
 annotate_proteins_similarity has a value which is a RAST_SDK.bool
 resolve_overlapping_features has a value which is a RAST_SDK.bool
-find_close_neighbors has a value which is a RAST_SDK.bool
 call_features_prophage_phispy has a value which is a RAST_SDK.bool
 retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 
@@ -701,7 +696,6 @@ annotate_proteins_kmer_v2 has a value which is a RAST_SDK.bool
 kmer_v1_parameters has a value which is a RAST_SDK.bool
 annotate_proteins_similarity has a value which is a RAST_SDK.bool
 resolve_overlapping_features has a value which is a RAST_SDK.bool
-find_close_neighbors has a value which is a RAST_SDK.bool
 call_features_prophage_phispy has a value which is a RAST_SDK.bool
 retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 
@@ -818,7 +812,6 @@ annotate_proteins_kmer_v2 has a value which is a RAST_SDK.bool
 kmer_v1_parameters has a value which is a RAST_SDK.bool
 annotate_proteins_similarity has a value which is a RAST_SDK.bool
 resolve_overlapping_features has a value which is a RAST_SDK.bool
-find_close_neighbors has a value which is a RAST_SDK.bool
 call_features_prophage_phispy has a value which is a RAST_SDK.bool
 retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 
@@ -847,7 +840,6 @@ annotate_proteins_kmer_v2 has a value which is a RAST_SDK.bool
 kmer_v1_parameters has a value which is a RAST_SDK.bool
 annotate_proteins_similarity has a value which is a RAST_SDK.bool
 resolve_overlapping_features has a value which is a RAST_SDK.bool
-find_close_neighbors has a value which is a RAST_SDK.bool
 call_features_prophage_phispy has a value which is a RAST_SDK.bool
 retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 

--- a/lib/RAST_SDK/RAST_SDKClient.py
+++ b/lib/RAST_SDK/RAST_SDKClient.py
@@ -63,8 +63,7 @@ class RAST_SDK(object):
            boolean), parameter "kmer_v1_parameters" of type "bool" (A binary
            boolean), parameter "annotate_proteins_similarity" of type "bool"
            (A binary boolean), parameter "resolve_overlapping_features" of
-           type "bool" (A binary boolean), parameter "find_close_neighbors"
-           of type "bool" (A binary boolean), parameter
+           type "bool" (A binary boolean), parameter
            "call_features_prophage_phispy" of type "bool" (A binary boolean),
            parameter "retain_old_anno_for_hypotheticals" of type "bool" (A
            binary boolean)
@@ -109,8 +108,7 @@ class RAST_SDK(object):
            boolean), parameter "kmer_v1_parameters" of type "bool" (A binary
            boolean), parameter "annotate_proteins_similarity" of type "bool"
            (A binary boolean), parameter "resolve_overlapping_features" of
-           type "bool" (A binary boolean), parameter "find_close_neighbors"
-           of type "bool" (A binary boolean), parameter
+           type "bool" (A binary boolean), parameter
            "call_features_prophage_phispy" of type "bool" (A binary boolean),
            parameter "retain_old_anno_for_hypotheticals" of type "bool" (A
            binary boolean)

--- a/lib/RAST_SDK/RAST_SDKImpl.pm
+++ b/lib/RAST_SDK/RAST_SDKImpl.pm
@@ -3,9 +3,9 @@ use strict;
 use Bio::KBase::Exceptions;
 # Use Semantic Versioning (2.0.0-rc.1)
 # http://semver.org 
-our $VERSION = '0.0.6';
-our $GIT_URL = 'https://github.com/kbaseapps//RAST_SDK';
-our $GIT_COMMIT_HASH = 'caabe1d46c5c3f73c00ac5c0b6760e40e101f25d';
+our $VERSION = '0.0.12';
+our $GIT_URL = 'git@github.com:kbaseapps/RAST_SDK.git';
+our $GIT_COMMIT_HASH = '4d601e6cb289caacf5e928e563513c41d3d1dcb5';
 
 =head1 NAME
 
@@ -468,9 +468,6 @@ sub annotate {
 			"resolve_overlapping_features_parameters" => {}
 		});
 	}
-	if (defined($parameters->{find_close_neighbors}) && $parameters->{find_close_neighbors} == 1)	{
-		push(@{$workflow->{stages}},{name => "find_close_neighbors"});
-	}
 	if (defined($parameters->{call_features_prophage_phispy}) && $parameters->{call_features_prophage_phispy} == 1)	{
 		push(@{$workflow->{stages}},{name => "call_features_prophage_phispy"});
 	}
@@ -865,7 +862,6 @@ AnnotateGenomeParams is a reference to a hash where the following keys are defin
 	kmer_v1_parameters has a value which is a RAST_SDK.bool
 	annotate_proteins_similarity has a value which is a RAST_SDK.bool
 	resolve_overlapping_features has a value which is a RAST_SDK.bool
-	find_close_neighbors has a value which is a RAST_SDK.bool
 	call_features_prophage_phispy has a value which is a RAST_SDK.bool
 	retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 genome_id is a string
@@ -910,7 +906,6 @@ AnnotateGenomeParams is a reference to a hash where the following keys are defin
 	kmer_v1_parameters has a value which is a RAST_SDK.bool
 	annotate_proteins_similarity has a value which is a RAST_SDK.bool
 	resolve_overlapping_features has a value which is a RAST_SDK.bool
-	find_close_neighbors has a value which is a RAST_SDK.bool
 	call_features_prophage_phispy has a value which is a RAST_SDK.bool
 	retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 genome_id is a string
@@ -976,7 +971,6 @@ sub annotate_genome
 	    kmer_v1_parameters => 1,
 	    annotate_proteins_similarity => 1,
 	    resolve_overlapping_features => 1,
-	    find_close_neighbors => 0,
 	    call_features_prophage_phispy => 1,
 	    retain_old_anno_for_hypotheticals => 1
 	});
@@ -1039,7 +1033,6 @@ AnnotateGenomesParams is a reference to a hash where the following keys are defi
 	kmer_v1_parameters has a value which is a RAST_SDK.bool
 	annotate_proteins_similarity has a value which is a RAST_SDK.bool
 	resolve_overlapping_features has a value which is a RAST_SDK.bool
-	find_close_neighbors has a value which is a RAST_SDK.bool
 	call_features_prophage_phispy has a value which is a RAST_SDK.bool
 	retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 GenomeParams is a reference to a hash where the following keys are defined:
@@ -1085,7 +1078,6 @@ AnnotateGenomesParams is a reference to a hash where the following keys are defi
 	kmer_v1_parameters has a value which is a RAST_SDK.bool
 	annotate_proteins_similarity has a value which is a RAST_SDK.bool
 	resolve_overlapping_features has a value which is a RAST_SDK.bool
-	find_close_neighbors has a value which is a RAST_SDK.bool
 	call_features_prophage_phispy has a value which is a RAST_SDK.bool
 	retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 GenomeParams is a reference to a hash where the following keys are defined:
@@ -1154,7 +1146,6 @@ sub annotate_genomes
 	    kmer_v1_parameters => 1,
 	    annotate_proteins_similarity => 1,
 	    resolve_overlapping_features => 1,
-	    find_close_neighbors => 0,
 	    call_features_prophage_phispy => 1,
 	    retain_old_anno_for_hypotheticals => 1
 	});
@@ -1203,7 +1194,6 @@ sub annotate_genomes
 		    kmer_v1_parameters
 		    annotate_proteins_similarity
 		    resolve_overlapping_features
-		    find_close_neighbors
 		    call_features_prophage_phispy
 		    retain_old_anno_for_hypotheticals
 		)];
@@ -1450,7 +1440,6 @@ annotate_proteins_kmer_v2 has a value which is a RAST_SDK.bool
 kmer_v1_parameters has a value which is a RAST_SDK.bool
 annotate_proteins_similarity has a value which is a RAST_SDK.bool
 resolve_overlapping_features has a value which is a RAST_SDK.bool
-find_close_neighbors has a value which is a RAST_SDK.bool
 call_features_prophage_phispy has a value which is a RAST_SDK.bool
 retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 
@@ -1484,7 +1473,6 @@ annotate_proteins_kmer_v2 has a value which is a RAST_SDK.bool
 kmer_v1_parameters has a value which is a RAST_SDK.bool
 annotate_proteins_similarity has a value which is a RAST_SDK.bool
 resolve_overlapping_features has a value which is a RAST_SDK.bool
-find_close_neighbors has a value which is a RAST_SDK.bool
 call_features_prophage_phispy has a value which is a RAST_SDK.bool
 retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 
@@ -1601,7 +1589,6 @@ annotate_proteins_kmer_v2 has a value which is a RAST_SDK.bool
 kmer_v1_parameters has a value which is a RAST_SDK.bool
 annotate_proteins_similarity has a value which is a RAST_SDK.bool
 resolve_overlapping_features has a value which is a RAST_SDK.bool
-find_close_neighbors has a value which is a RAST_SDK.bool
 call_features_prophage_phispy has a value which is a RAST_SDK.bool
 retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 
@@ -1630,7 +1617,6 @@ annotate_proteins_kmer_v2 has a value which is a RAST_SDK.bool
 kmer_v1_parameters has a value which is a RAST_SDK.bool
 annotate_proteins_similarity has a value which is a RAST_SDK.bool
 resolve_overlapping_features has a value which is a RAST_SDK.bool
-find_close_neighbors has a value which is a RAST_SDK.bool
 call_features_prophage_phispy has a value which is a RAST_SDK.bool
 retain_old_anno_for_hypotheticals has a value which is a RAST_SDK.bool
 

--- a/lib/RAST_SDK/RAST_SDKImpl.pm
+++ b/lib/RAST_SDK/RAST_SDKImpl.pm
@@ -570,7 +570,6 @@ sub annotate {
 		$funchash->{$rolename} = $output->[0]->{data}->{term_hash}->{$term};
 	}
 	my $newftrs = 0;
-	my $functionchanges = 0;
 	my $proteins = 0;
 	my $others = 0;
 	my $seedfunctions;
@@ -586,9 +585,6 @@ sub annotate {
 				my $func = $ftr->{function};
 				if (not defined($func)) {
 					$func = "";
-				}
-				if (!defined($genehash->{$ftr->{id}}->{$func})) {
-					$functionchanges++;
 				}
 			}
 			if (!defined($ftr->{type}) && $ftr->{id} =~ m/(\w+)\.\d+$/) {
@@ -751,9 +747,8 @@ sub annotate {
 			}
 		}
 	}
-	if (defined($genehash)) {
+	if (defined($inputgenome)) {
 		$message .= " In addition to the original ".keys(%{$genehash})." features, ".$newftrs." new features were called.";
-		$message .= " Of the original features, ".$functionchanges." were re-annotated by RAST with new functions.";
 	}
 	$message .= " Overall, a total of ".$seedfunctions." genes are now annotated with ".keys(%{$genomefunchash})." distinct functions. Of these functions, ".keys(%{$seedfunchash})." are a match for the SEED annotation ontology.";
 	print($message);

--- a/lib/RAST_SDK/RAST_SDKImpl.pm
+++ b/lib/RAST_SDK/RAST_SDKImpl.pm
@@ -1149,8 +1149,6 @@ sub annotate_genomes
 	    call_features_prophage_phispy => 1,
 	    retain_old_anno_for_hypotheticals => 1
 	});
-	my $success = [];
-	my $failed = {};
 	my $htmlmessage = "<p>";
 	my $genomes = $params->{input_genomes};
 	if (defined($params->{genome_text})) {
@@ -1163,8 +1161,8 @@ sub annotate_genomes
 		my $input = $genomes->[$i];
 		if ($input =~ m/\//) {
 			my $array = [split(/\//,$input)];
-			my $info = Bio::KBase::kbaseenv::get_object_info([
-				Bio::KBase::kbaseenv::buildref($array->[0],$array->[1],$array->[2])
+			my $info = Bio::KBase::kbaseenv::get_object_info([{ref=>
+				Bio::KBase::kbaseenv::buildref($array->[0],$array->[1],$array->[2])}
 			],0);
 			$input = $info->[0]->[1];
 		}

--- a/lib/src/us/kbase/rastsdk/AnnotateGenomeParams.java
+++ b/lib/src/us/kbase/rastsdk/AnnotateGenomeParams.java
@@ -42,7 +42,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "kmer_v1_parameters",
     "annotate_proteins_similarity",
     "resolve_overlapping_features",
-    "find_close_neighbors",
     "call_features_prophage_phispy",
     "retain_old_anno_for_hypotheticals"
 })
@@ -94,8 +93,6 @@ public class AnnotateGenomeParams {
     private Long annotateProteinsSimilarity;
     @JsonProperty("resolve_overlapping_features")
     private Long resolveOverlappingFeatures;
-    @JsonProperty("find_close_neighbors")
-    private Long findCloseNeighbors;
     @JsonProperty("call_features_prophage_phispy")
     private Long callFeaturesProphagePhispy;
     @JsonProperty("retain_old_anno_for_hypotheticals")
@@ -447,21 +444,6 @@ public class AnnotateGenomeParams {
         return this;
     }
 
-    @JsonProperty("find_close_neighbors")
-    public Long getFindCloseNeighbors() {
-        return findCloseNeighbors;
-    }
-
-    @JsonProperty("find_close_neighbors")
-    public void setFindCloseNeighbors(Long findCloseNeighbors) {
-        this.findCloseNeighbors = findCloseNeighbors;
-    }
-
-    public AnnotateGenomeParams withFindCloseNeighbors(Long findCloseNeighbors) {
-        this.findCloseNeighbors = findCloseNeighbors;
-        return this;
-    }
-
     @JsonProperty("call_features_prophage_phispy")
     public Long getCallFeaturesProphagePhispy() {
         return callFeaturesProphagePhispy;
@@ -504,7 +486,7 @@ public class AnnotateGenomeParams {
 
     @Override
     public String toString() {
-        return ((((((((((((((((((((((((((((((((((((((((((((((((((((((("AnnotateGenomeParams"+" [workspace=")+ workspace)+", inputGenome=")+ inputGenome)+", inputContigset=")+ inputContigset)+", geneticCode=")+ geneticCode)+", domain=")+ domain)+", scientificName=")+ scientificName)+", outputGenome=")+ outputGenome)+", callFeaturesRRNASEED=")+ callFeaturesRRNASEED)+", callFeaturesTRNATrnascan=")+ callFeaturesTRNATrnascan)+", callSelenoproteins=")+ callSelenoproteins)+", callPyrrolysoproteins=")+ callPyrrolysoproteins)+", callFeaturesRepeatRegionSEED=")+ callFeaturesRepeatRegionSEED)+", callFeaturesInsertionSequences=")+ callFeaturesInsertionSequences)+", callFeaturesStrepSuisRepeat=")+ callFeaturesStrepSuisRepeat)+", callFeaturesStrepPneumoRepeat=")+ callFeaturesStrepPneumoRepeat)+", callFeaturesCrispr=")+ callFeaturesCrispr)+", callFeaturesCDSGlimmer3=")+ callFeaturesCDSGlimmer3)+", callFeaturesCDSProdigal=")+ callFeaturesCDSProdigal)+", callFeaturesCDSGenemark=")+ callFeaturesCDSGenemark)+", annotateProteinsKmerV2=")+ annotateProteinsKmerV2)+", kmerV1Parameters=")+ kmerV1Parameters)+", annotateProteinsSimilarity=")+ annotateProteinsSimilarity)+", resolveOverlappingFeatures=")+ resolveOverlappingFeatures)+", findCloseNeighbors=")+ findCloseNeighbors)+", callFeaturesProphagePhispy=")+ callFeaturesProphagePhispy)+", retainOldAnnoForHypotheticals=")+ retainOldAnnoForHypotheticals)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((((((((((((((((((((((((((((((((((("AnnotateGenomeParams"+" [workspace=")+ workspace)+", inputGenome=")+ inputGenome)+", inputContigset=")+ inputContigset)+", geneticCode=")+ geneticCode)+", domain=")+ domain)+", scientificName=")+ scientificName)+", outputGenome=")+ outputGenome)+", callFeaturesRRNASEED=")+ callFeaturesRRNASEED)+", callFeaturesTRNATrnascan=")+ callFeaturesTRNATrnascan)+", callSelenoproteins=")+ callSelenoproteins)+", callPyrrolysoproteins=")+ callPyrrolysoproteins)+", callFeaturesRepeatRegionSEED=")+ callFeaturesRepeatRegionSEED)+", callFeaturesInsertionSequences=")+ callFeaturesInsertionSequences)+", callFeaturesStrepSuisRepeat=")+ callFeaturesStrepSuisRepeat)+", callFeaturesStrepPneumoRepeat=")+ callFeaturesStrepPneumoRepeat)+", callFeaturesCrispr=")+ callFeaturesCrispr)+", callFeaturesCDSGlimmer3=")+ callFeaturesCDSGlimmer3)+", callFeaturesCDSProdigal=")+ callFeaturesCDSProdigal)+", callFeaturesCDSGenemark=")+ callFeaturesCDSGenemark)+", annotateProteinsKmerV2=")+ annotateProteinsKmerV2)+", kmerV1Parameters=")+ kmerV1Parameters)+", annotateProteinsSimilarity=")+ annotateProteinsSimilarity)+", resolveOverlappingFeatures=")+ resolveOverlappingFeatures)+", callFeaturesProphagePhispy=")+ callFeaturesProphagePhispy)+", retainOldAnnoForHypotheticals=")+ retainOldAnnoForHypotheticals)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/test/full_shewanella_test.pl
+++ b/test/full_shewanella_test.pl
@@ -136,7 +136,6 @@ sub reannotate_genome {
              "kmer_v1_parameters"=>'1',
              "annotate_proteins_similarity"=>'0',
              "resolve_overlapping_features"=>'0',
-             "find_close_neighbors"=>'0',
              "call_features_prophage_phispy"=>'0',
              "output_genome"=>$genome_obj_name,
              "workspace"=>get_ws_name()

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -3,7 +3,6 @@ script_dir=$(dirname "$(readlink -f "$0")")
 export KB_DEPLOYMENT_CONFIG=$script_dir/../deploy.cfg
 export KB_AUTH_TOKEN=`cat /kb/module/work/token`
 export PERL5LIB=$script_dir/../lib:$PATH:$PERL5LIB
-#Used to mock out certain binaries (e.g. kmer_guts)
-#export PATH=$script_dir/../test/:$PATH
 cd $script_dir/../test
-perl -e 'opendir my $dh, "."; my @l = grep { /\\.pl$/ } readdir $dh; foreach my $s (@l) { print("Running ".$s."\n"); system "perl", $s; }'
+perl -e 'opendir my $dh, "."; my @l = grep { /\.pl$/ } readdir $dh; foreach my $s (@l) { print("Running ".$s."
+"); system "perl", $s; }'

--- a/ui/narrative/methods/annotate_contigset/display.yaml
+++ b/ui/narrative/methods/annotate_contigset/display.yaml
@@ -184,14 +184,6 @@ parameters :
         long-hint  : |
             Perform basic gene overlap removal
                         
-    find_close_neighbors :
-        ui-name : |
-            Find close neighbors
-        short-hint : |
-            Find close neighbors
-        long-hint  : |
-            Find close neighbors
-                        
     call_features_prophage_phispy :
         ui-name : |
             Find prophage elements with phispy

--- a/ui/narrative/methods/annotate_contigset/spec.json
+++ b/ui/narrative/methods/annotate_contigset/spec.json
@@ -248,17 +248,6 @@
       "unchecked_value": 0
     }
   }, {
-    "id": "find_close_neighbors",
-    "optional":false,
-    "advanced":true,
-    "allow_multiple":false,
-    "default_values":["1"],
-    "field_type" : "checkbox",
-    "checkbox_options":{
-      "checked_value": 1,
-      "unchecked_value": 0
-    }
-  }, {
     "id": "call_features_prophage_phispy",
     "optional":false,
     "advanced":true,
@@ -354,10 +343,6 @@
         {
           "input_parameter": "resolve_overlapping_features",
           "target_property": "resolve_overlapping_features"
-        },
-        {
-          "input_parameter": "find_close_neighbors",
-          "target_property": "find_close_neighbors"
         },
         {
           "input_parameter": "call_features_prophage_phispy",

--- a/ui/narrative/methods/annotate_plant_transcripts/spec.json
+++ b/ui/narrative/methods/annotate_plant_transcripts/spec.json
@@ -124,10 +124,6 @@
 	},
 	{
 	  "constant_value":"0",
-	  "target_property":"find_close_neighbors"
-	},
-	{
-	  "constant_value":"0",
 	  "target_property":"call_features_prophage_phispy"
 	},
         {

--- a/ui/narrative/methods/reannotate_microbial_genome/display.yaml
+++ b/ui/narrative/methods/reannotate_microbial_genome/display.yaml
@@ -169,14 +169,6 @@ parameters :
         long-hint  : |
             See manual page for description of annotation pipieline
                         
-    find_close_neighbors :
-        ui-name : |
-            Find close neighbors
-        short-hint : |
-            See manual page for description of annotation pipieline
-        long-hint  : |
-            See manual page for description of annotation pipieline
-                        
     call_features_prophage_phispy :
         ui-name : |
             Call features prophage phispy

--- a/ui/narrative/methods/reannotate_microbial_genome/spec.json
+++ b/ui/narrative/methods/reannotate_microbial_genome/spec.json
@@ -207,17 +207,6 @@
       "unchecked_value": 0
     }
   }, {
-    "id": "find_close_neighbors",
-    "optional":false,
-    "advanced":true,
-    "allow_multiple":false,
-    "default_values":["1"],
-    "field_type" : "checkbox",
-    "checkbox_options":{
-      "checked_value": 1,
-      "unchecked_value": 0
-    }
-  }, {
     "id": "call_features_prophage_phispy",
     "optional":false,
     "advanced":true,
@@ -301,10 +290,6 @@
         {
           "input_parameter": "resolve_overlapping_features",
           "target_property": "resolve_overlapping_features"
-        },
-        {
-          "input_parameter": "find_close_neighbors",
-          "target_property": "find_close_neighbors"
         },
         {
           "input_parameter": "call_features_prophage_phispy",

--- a/ui/narrative/methods/reannotate_microbial_genomes/display.yaml
+++ b/ui/narrative/methods/reannotate_microbial_genomes/display.yaml
@@ -54,7 +54,7 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-            
+
     call_features_tRNA_trnascan :
         ui-name : |
             Call features tRNA trnascan
@@ -62,7 +62,7 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-                
+
     call_selenoproteins :
         ui-name : |
             Call selenoproteins
@@ -70,7 +70,7 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-                        
+
     call_pyrrolysoproteins :
         ui-name : |
             Call pyrrolysoproteins
@@ -78,7 +78,7 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-                        
+
     call_features_repeat_region_SEED :
         ui-name : |
             Call features repeat region SEED
@@ -86,7 +86,7 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-                        
+
     call_features_insertion_sequences :
         ui-name : |
             Call features insertion sequences
@@ -94,7 +94,7 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-                        
+
     call_features_strep_suis_repeat :
         ui-name : |
             Call features strep suis repeat
@@ -102,7 +102,7 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-                        
+
     call_features_strep_pneumo_repeat :
         ui-name : |
             Call features strep pneumo repeat
@@ -110,7 +110,7 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-                        
+
     call_features_crispr :
         ui-name : |
             Call features crispr
@@ -118,7 +118,7 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-                        
+
     call_features_CDS_glimmer3 :
         ui-name : |
             Call features CDS glimmer3
@@ -126,7 +126,7 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-                        
+
     call_features_CDS_prodigal :
         ui-name : |
             Call features CDS prodigal
@@ -134,7 +134,7 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-                        
+
     annotate_proteins_kmer_v2 :
         ui-name : |
             Annotate proteins kmer v2
@@ -143,7 +143,7 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-                        
+
     kmer_v1_parameters :
         ui-name : |
             Kmer v1 parameters
@@ -151,7 +151,7 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-                        
+
     annotate_proteins_similarity :
         ui-name : |
             Annotate proteins similarity
@@ -159,7 +159,7 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-                
+
     retain_old_anno_for_hypotheticals :
         ui-name : |
             Retain old annotations for hypotheticals
@@ -167,18 +167,10 @@ parameters :
             See manual page for description of annotation pipieline
         long-hint  : |
             See manual page for description of annotation pipieline
-                
+
     resolve_overlapping_features :
         ui-name : |
             Resolve overlapping features
-        short-hint : |
-            See manual page for description of annotation pipieline
-        long-hint  : |
-            See manual page for description of annotation pipieline
-                        
-    find_close_neighbors :
-        ui-name : |
-            Find close neighbors
         short-hint : |
             See manual page for description of annotation pipieline
         long-hint  : |

--- a/ui/narrative/methods/reannotate_microbial_genomes/spec.json
+++ b/ui/narrative/methods/reannotate_microbial_genomes/spec.json
@@ -206,17 +206,6 @@
       "unchecked_value": 0
     }
   }, {
-    "id": "find_close_neighbors",
-    "optional":false,
-    "advanced":true,
-    "allow_multiple":false,
-    "default_values":["1"],
-    "field_type" : "checkbox",
-    "checkbox_options":{
-      "checked_value": 1,
-      "unchecked_value": 0
-    }
-  }, {
     "id": "call_features_prophage_phispy",
     "optional":false,
     "advanced":true,
@@ -304,10 +293,6 @@
         {
           "input_parameter": "resolve_overlapping_features",
           "target_property": "resolve_overlapping_features"
-        },
-        {
-          "input_parameter": "find_close_neighbors",
-          "target_property": "find_close_neighbors"
         },
         {
           "input_parameter": "call_features_prophage_phispy",


### PR DESCRIPTION
This PR has 3 major fixes:
1. It removes the find_close_neighbors option from all RAST ui and apps. The results of this optional analysis are not very helpful because they are tied to the SEED genomes not our reference genomes. The close genome statistic has been removed from the new genome

2. It fixes a faulty call in the annotate multiple genomes app that had escaped prior notice and adds a test of that call to the suite to hopefully avoid future regressions.

3. It removes a faulty statistic from the RAST report text on the number of gene that have changed function.

I tested the unit tests on docker01 and the UI in AppDev.