### PR TITLE
Missing '}' in AssemblyUtilClient.pm

### DIFF
--- a/lib/AssemblyUtil/AssemblyUtilClient.pm
+++ b/lib/AssemblyUtil/AssemblyUtilClient.pm
@@ -159,6 +159,7 @@ sub _check_job {
             finished  => 0,
             failed  => 1,
         };
+	}
 }
 
 


### PR DESCRIPTION
@JamesJeffryes  - Can you merge this PR for me? Thanks.

In commit 8358b6c62e98ac0865603d4f538b7a5291d95ca7, File AssemblyUtilClient.pm, around lines 158=161, a ‘}’ was deleted and it was replaced with both a ‘{‘ and a ‘}’.  Need to add another '}'.