### PR TITLE
Remove domain 'Unknown' from multiple genomes/assemblies because tools won't run

### DIFF
--- a/bootstrap/build.prodigal
+++ b/bootstrap/build.prodigal
@@ -17,7 +17,7 @@ if (@ARGV)
 
 -d $dest || mkdir $dest;
 
-my $vers = "2.6.1";
+my $vers = "2.6.3";
 
 my $prodigal_dir = "Prodigal-$vers";
 my $prodigal_tar = "v$vers.tar.gz";

--- a/lib/RAST_SDK/RAST_SDKImpl.pm
+++ b/lib/RAST_SDK/RAST_SDKImpl.pm
@@ -252,6 +252,9 @@ sub annotate_process {
 		$parameters->{domain} = $inputgenome->{domain};
 		$parameters->{scientific_name} = $inputgenome->{scientific_name};
 	} elsif (defined($parameters->{input_contigset})) {
+		$parameters->{genetic_code} = $inputgenome->{genetic_code};
+		$parameters->{domain} = $inputgenome->{domain};
+		$parameters->{scientific_name} = $inputgenome->{scientific_name};
 		$contigobj = $self->util_get_contigs($parameters->{workspace},$parameters->{input_contigset});	
 	} else {
 		Bio::KBase::utilities::error("Neither contigs nor genome specified!");
@@ -268,7 +271,7 @@ sub annotate_process {
 				delete $inputgenome->{contigs}->[$i]->{sequence};
 			}
 		}
-		
+	
 		if ($contigobj->{_kbasetype} eq "ContigSet") {
 			$inputgenome->{contigset_ref} = $contigobj->{_reference};
 		} else {
@@ -1440,7 +1443,6 @@ sub annotate_genomes
 		    call_features_crispr
 		    call_features_CDS_glimmer3
 		    call_features_CDS_prodigal
-		    call_features_CDS_genemark
 		    annotate_proteins_kmer_v2
 		    kmer_v1_parameters
 		    annotate_proteins_similarity
@@ -1455,9 +1457,10 @@ sub annotate_genomes
 
 		if ($obj_type =~ /KBaseGenomeAnnotations\.Assembly/) {
 			$currentparams->{'scientific_name'} = 'unknown taxon';
-			$currentparams->{'domain'} = 'Unknown';
+			$currentparams->{'domain'} = 'B';
 			$currentparams->{'genetic_code'} = 11;
 			$currentparams->{'input_contigset'} = delete $currentparams->{'input_genome'};
+			delete $currentparams->{'retain_old_anno_for_hypotheticals'};
 		}
 			
 		eval {

--- a/ui/narrative/methods/annotate_contigset/spec.json
+++ b/ui/narrative/methods/annotate_contigset/spec.json
@@ -68,12 +68,6 @@
           "display": "4 (Mycoplasmaea, Spiroplasmaea, Ureoplasmaea, and Fungal Mitochondria)",
           "id": "fast",
           "ui_name": "4 (Mycoplasmaea, Spiroplasmaea, Ureoplasmaea, and Fungal Mitochondria)"
-		},
-		{
-          "value": "25",
-          "display": "25 (Candidate Division SR1 and Gracilibacteria Code)",
-          "id": "fast",
-          "ui_name": "25 (Candidate Division SR1 and Gracilibacteria Code)"
         }
       ]
     }

--- a/ui/narrative/methods/annotate_contigset/spec.json
+++ b/ui/narrative/methods/annotate_contigset/spec.json
@@ -68,6 +68,12 @@
           "display": "4 (Mycoplasmaea, Spiroplasmaea, Ureoplasmaea, and Fungal Mitochondria)",
           "id": "fast",
           "ui_name": "4 (Mycoplasmaea, Spiroplasmaea, Ureoplasmaea, and Fungal Mitochondria)"
+		},
+		{
+          "value": "25",
+          "display": "25 (Candidate Division SR1 and Gracilibacteria Code)",
+          "id": "fast",
+          "ui_name": "25 (Candidate Division SR1 and Gracilibacteria Code)"
         }
       ]
     }

--- a/ui/narrative/methods/annotate_contigsets/display.yaml
+++ b/ui/narrative/methods/annotate_contigsets/display.yaml
@@ -47,6 +47,30 @@ parameters :
         long-hint  : |
             List of assemblies to annotate, delimited with semicolon
 
+    scientific_name :
+        ui-name : |
+            Scientific Name
+        short-hint : |
+            The scientific name to assign to the genome
+        long-hint  : |
+            The scientific name to assign to the genome
+
+    domain :
+        ui-name : |
+            Domain
+        short-hint : |
+            The domain of life of the organism being annotated
+        long-hint  : |
+            The domain of life of the organism being annotated
+
+    genetic_code :
+        ui-name : |
+            Genetic Code
+        short-hint : |
+            The genetic code used in translating to protein sequences
+        long-hint  : |
+            The genetic code used in translating to protein sequences
+
     call_features_rRNA_SEED :
         ui-name : |
             Call rRNAs

--- a/ui/narrative/methods/annotate_contigsets/spec.json
+++ b/ui/narrative/methods/annotate_contigsets/spec.json
@@ -34,7 +34,7 @@
     "optional":false,
     "advanced":true,
     "allow_multiple":false,
-    "default_values":["0"],
+    "default_values":["1"],
     "field_type" : "checkbox",
     "checkbox_options":{
       "checked_value": 1,
@@ -45,7 +45,7 @@
     "optional":false,
     "advanced":true,
     "allow_multiple":false,
-    "default_values":["0"],
+    "default_values":["1"],
     "field_type" : "checkbox",
     "checkbox_options":{
       "checked_value": 1,
@@ -56,7 +56,7 @@
     "optional":false,
     "advanced":true,
     "allow_multiple":false,
-    "default_values":["0"],
+    "default_values":["1"],
     "field_type" : "checkbox",
     "checkbox_options":{
       "checked_value": 1,
@@ -67,7 +67,7 @@
     "optional":false,
     "advanced":true,
     "allow_multiple":false,
-    "default_values":["0"],
+    "default_values":["1"],
     "field_type" : "checkbox",
     "checkbox_options":{
       "checked_value": 1,
@@ -78,7 +78,7 @@
     "optional":false,
     "advanced":true,
     "allow_multiple":false,
-    "default_values":["0"],
+    "default_values":["1"],
     "field_type" : "checkbox",
     "checkbox_options":{
       "checked_value": 1,
@@ -89,7 +89,7 @@
     "optional":false,
     "advanced":true,
     "allow_multiple":false,
-    "default_values":["0"],
+    "default_values":["1"],
     "field_type" : "checkbox",
     "checkbox_options":{
       "checked_value": 1,
@@ -100,7 +100,7 @@
     "optional":false,
     "advanced":true,
     "allow_multiple":false,
-    "default_values":["0"],
+    "default_values":["1"],
     "field_type" : "checkbox",
     "checkbox_options":{
       "checked_value": 1,
@@ -111,7 +111,7 @@
     "optional":false,
     "advanced":true,
     "allow_multiple":false,
-    "default_values":["0"],
+    "default_values":["1"],
     "field_type" : "checkbox",
     "checkbox_options":{
       "checked_value": 1,
@@ -122,7 +122,7 @@
     "optional":false,
     "advanced":true,
     "allow_multiple":false,
-    "default_values":["0"],
+    "default_values":["1"],
     "field_type" : "checkbox",
     "checkbox_options":{
       "checked_value": 1,
@@ -133,7 +133,7 @@
     "optional":false,
     "advanced":true,
     "allow_multiple":false,
-    "default_values":["0"],
+    "default_values":["1"],
     "field_type" : "checkbox",
     "checkbox_options":{
       "checked_value": 1,
@@ -173,22 +173,11 @@
       "unchecked_value": 0
     }
   }, {
-    "id": "retain_old_anno_for_hypotheticals",
-    "optional":false,
-    "advanced":true,
-    "allow_multiple":false,
-    "default_values":["0"],
-    "field_type" : "checkbox",
-    "checkbox_options":{
-      "checked_value": 1,
-      "unchecked_value": 0
-    }
-  }, {
     "id": "resolve_overlapping_features",
     "optional":false,
     "advanced":true,
     "allow_multiple":false,
-    "default_values":["0"],
+    "default_values":["1"],
     "field_type" : "checkbox",
     "checkbox_options":{
       "checked_value": 1,
@@ -292,10 +281,6 @@
         {
           "input_parameter": "call_features_prophage_phispy",
           "target_property": "call_features_prophage_phispy"
-        },
-        {
-          "input_parameter": "retain_old_anno_for_hypotheticals",
-          "target_property": "retain_old_anno_for_hypotheticals"
         },
         {
           "input_parameter": "output_genome",

--- a/ui/narrative/methods/annotate_contigsets/spec.json
+++ b/ui/narrative/methods/annotate_contigsets/spec.json
@@ -30,6 +30,65 @@
             "n_rows" : 10
     	}
   }, {
+    "id" : "scientific_name",
+    "optional" : true,
+    "advanced" : true,
+    "allow_multiple" : false,
+    "default_values" : [ "unknown taxon" ],
+    "field_type" : "text"
+  }, {
+    "id" : "domain",
+    "optional" : true,
+    "advanced" : true,
+    "allow_multiple" : false,
+    "default_values" : [ "U" ],
+    "field_type" : "dropdown",
+     "dropdown_options":{
+      "options": [
+        {
+          "value": "B",
+          "display": "B (Bacteria)",
+          "id": "B",
+          "ui_name": "B (Bacteria)"
+        },
+        {
+          "value": "A",
+          "display": "A (Archaea)",
+          "id": "fast",
+          "ui_name": "A (Archaea)"
+        },
+        {
+          "value": "U",
+          "display": "U (Unknown)",
+          "id": "fast",
+          "ui_name": "U (Unknown)"
+        }
+      ]
+    }
+  }, {
+    "id" : "genetic_code",
+    "optional" : true,
+    "advanced" : true,
+    "allow_multiple" : false,
+    "default_values" : [ "11" ],
+    "field_type" : "dropdown",
+     "dropdown_options":{
+      "options": [
+        {
+          "value": "11",
+          "display": "11 (Archaea, most Bacteria, most Virii, and some Mitochondria)",
+          "id": "11",
+          "ui_name": "11 (Archaea, most Bacteria, most Virii, and some Mitochondria)"
+        },
+        {
+          "value": "4",
+          "display": "4 (Mycoplasmaea, Spiroplasmaea, Ureoplasmaea, and Fungal Mitochondria)",
+          "id": "fast",
+          "ui_name": "4 (Mycoplasmaea, Spiroplasmaea, Ureoplasmaea, and Fungal Mitochondria)"
+        }
+      ]
+    }
+  }, {
     "id": "call_features_rRNA_SEED",
     "optional":false,
     "advanced":true,

--- a/ui/narrative/methods/annotate_contigsets/spec.json
+++ b/ui/narrative/methods/annotate_contigsets/spec.json
@@ -41,7 +41,7 @@
     "optional" : true,
     "advanced" : true,
     "allow_multiple" : false,
-    "default_values" : [ "U" ],
+    "default_values" : [ "B" ],
     "field_type" : "dropdown",
      "dropdown_options":{
       "options": [

--- a/ui/narrative/methods/annotate_contigsets/spec.json
+++ b/ui/narrative/methods/annotate_contigsets/spec.json
@@ -56,12 +56,6 @@
           "display": "A (Archaea)",
           "id": "fast",
           "ui_name": "A (Archaea)"
-        },
-        {
-          "value": "U",
-          "display": "U (Unknown)",
-          "id": "fast",
-          "ui_name": "U (Unknown)"
         }
       ]
     }


### PR DESCRIPTION
The default domain for multiple genomes and multiple assemblies has been set to 'Unknown'. This causes problems for the tools that do a domain check for A/B/V and will fail if one of these aren't found. The tools include the kb_seed implementation of selenoproteins, pyrroproteins, prodigal, crisprs, and phage (phiSpy). To be extra careful, added code to make sure assemblies have scientific name, domain, and genetic code before requesting annotation.

In addition, Prodigal was upgraded to the current version in preparation for genetic code 25. The dropdown for genetic code 25 was added in one commit but had to be removed in the next commit because the kb_seed module needs to be updated. The kb_seed is failing genes/genomes with genetic code 25.
@JamesJeffryes 