### PR TITLE
Fix bugs in redirecting reports

### DIFF
--- a/lib/RAST_SDK/RAST_SDKImpl.pm
+++ b/lib/RAST_SDK/RAST_SDKImpl.pm
@@ -1471,7 +1471,7 @@ sub annotate_genomes
 		my $list = [qw(
 			workspace
 			scientific_name
-			genetic_name
+			genetic_code
 			domain
 			call_features_rRNA_SEED
 		    call_features_tRNA_trnascan
@@ -1506,9 +1506,9 @@ sub annotate_genomes
 			$htmlmessage .= $message;
 		};
 		if ($@) {
-			$htmlmessage .= $input." failed!<br>\n\n";
+			$htmlmessage .= $input." failed!\n\n";
 		} else {
-			$htmlmessage .= $input." succeeded!<br>\n\n";
+			$htmlmessage .= $input." succeeded!\n\n";
 		}
 	}
 		
@@ -1525,20 +1525,20 @@ sub annotate_genomes
 		}
 
 
-	my $path = "/kb/module/work/tmp/microbial_genome_report.$params->{output_genome}";
+	my $path = "/kb/module/work/tmp/annotation_report.$params->{output_genome}";
 	open (FH,">$path") || warn("Did not create the output file\n");
 	print FH $htmlmessage;
 	close FH;
-	$htmlmessage .= "<pre>$htmlmessage</pre>\n\n";
+	$htmlmessage = "<pre>$htmlmessage</pre>\n\n";
     my $reportfile = Bio::KBase::utilities::add_report_file({
     	workspace_name => $params->{workspace},
-    	name =>  "microbial_genome_report.$params->{output_genome}",
+    	name =>  "annotation_report.$params->{output_genome}",
 		path => $path,
 		description => 'Microbial Annotation Report'
     });
 
 	Bio::KBase::utilities::print_report_message({
-		message => $htmlmessage,html=>1,append => 0
+		message => $htmlmessage,html=>0,append => 0
 	});
     my $reportout = Bio::KBase::kbaseenv::create_report({
     	workspace_name => $params->{workspace},

--- a/test/assemblySets_test.pl
+++ b/test/assemblySets_test.pl
@@ -41,11 +41,10 @@ sub reannotate_genomes {
              "call_features_strep_pneumo_repeat"=>'0',
              "call_features_crispr"=>'0',
              "call_features_CDS_glimmer3"=>'0',
-             "call_features_CDS_prodigal"=>'0',
+             "call_features_CDS_prodigal"=>'1',
              "annotate_proteins_kmer_v2"=>'0',
              "kmer_v1_parameters"=>'0',
              "annotate_proteins_similarity"=>'0',
-             "retain_old_anno_for_hypotheticals"=>'0',
              "resolve_overlapping_features"=>'0',
              "call_features_prophage_phispy"=>'0',
              "output_genome"=>$genome_obj_name,
@@ -72,29 +71,27 @@ sub prepare_assembly {
 }
 
 
-my $DEBUG = 'Y';
-#my $genome_obj_name1 = "Dactylopius coccus";
-#my $assembly_ref1 = "40046/2/1";
-#my $genome_obj_name2 = "Drosophila melanogaster";
-#my $assembly_ref2 = "40046/3/1";
-#my $genome_obj_name3 = "Nomada ferruginata";
-#my $assembly_ref3 = "40046/4/1";
+my $DEBUG = 'N';
+my $assembly_obj_name1 = "Dactylopius coccus";
+my $assembly_ref1 = "40046/5/1";
+   $assembly_ref1 = "40619/11/1";
+my $assembly_obj_name2 = "Drosophila melanogaster";
+my $assembly_ref2 = "40046/6/1";
+   $assembly_ref2 = "40619/39/1";
+my $assembly_obj_name3 = "Nomada ferruginata";
+my $assembly_ref3 = "40046/7/1";
 
-my $assembly_obj_name1 = "bogus.fna";
-my $assembly_ref1 = prepare_assembly($assembly_obj_name1);
-my $assembly_ref_new1;
-my $assembly_ref_old1;
+if ($DEBUG ne 'Y') {
+	$assembly_obj_name1 = "bogus.fna";
+	$assembly_ref1 = prepare_assembly($assembly_obj_name1);
+		
+	$assembly_obj_name2 = "bogus2.fna";
+	$assembly_ref2 = prepare_assembly($assembly_obj_name2);
 	
-my $assembly_obj_name2 = "bogus2.fna";
-my $assembly_ref2 = prepare_assembly($assembly_obj_name2);
-my $assembly_ref_new2;
-my $assembly_ref_old2;
-	
-my $assembly_obj_name3 = "bogus2.fna";
-my $assembly_ref3 = prepare_assembly($assembly_obj_name2);
-my $assembly_ref_new3;
-my $assembly_ref_old3;
-	
+	$assembly_obj_name3 = "bogus2.fna";
+	$assembly_ref3 = prepare_assembly($assembly_obj_name2);
+}
+
 my $assembly_set_name = 'new_assembly_set';
 my $assembly_set = $su->KButil_Build_AssemblySet({
      	workspace_name => get_ws_name(),
@@ -124,14 +121,6 @@ lives_ok {
 
 lives_ok {
 	if ($DEBUG eq 'Y') {
-		my $assembly_set_name = 'new_genome_set';
-		my $assembly_set = $su->KButil_Build_AssemblySet({
-        	workspace_name => get_ws_name(),
-        	input_refs => [$assembly_ref1,$assembly_ref2],
-        	output_name => $assembly_set_name,
-        	desc => 'GenomeSet Description'
-    	});
-
 		my $gs = get_ws_name() . "/" . $assembly_set_name ;
 		my $info = $ws_client->get_objects([{ref=>$gs}])->[0]->{info};
 		my $newref = $info->[6]."/".$info->[0]."/".$info->[4];

--- a/test/carsonella_rRNA_tRNA.pl
+++ b/test/carsonella_rRNA_tRNA.pl
@@ -52,14 +52,23 @@ sub reannotate_genome {
     return make_impl_call("RAST_SDK.annotate_genome", $params);
 }
 
+my $DEBUG = 0;
 my $diff_count   = 0;
 my $num_func_in  = 0;
 my $num_func_out = 0;
 my $genome_obj_name = "Carsonella";
+my $genome_ref = '';
+
 lives_ok {
-    my $genome_gbff_name = "Carsonella.gbk";
-    my ($tmp_genome_obj, $genome_ref) = prepare_gbff($genome_gbff_name,$genome_obj_name);
-#	my $genome_ref = "15792/125010/2";
+	if ($DEBUG) {
+		$genome_ref = "15792/210698/1";
+	} else {
+  		my $tmp_genome_obj;
+	  	my $genome_gbff_name = "Carsonella.gbk";
+    	($tmp_genome_obj, $genome_ref) = prepare_gbff($genome_gbff_name,$genome_obj_name);
+	}
+
+
 	my ($orig_genome,$orig_funcs) = &get_and_prep($genome_ref);
 
 	print "number of input features = ".scalar  @{$orig_genome->{features}}."\n";

--- a/test/genomesets_and_multiples.pl
+++ b/test/genomesets_and_multiples.pl
@@ -54,13 +54,20 @@ sub reannotate_genomes {
     return make_impl_call("RAST_SDK.annotate_genomes", $params);
 }
 
-my $DEBUG = 'Y';
-my $genome_obj_name1 = "Dactylopius coccus";
+my $DEBUG = 'N';
+my $genome_obj_name1 = "Dactylopius_coccus";
 my $genome_ref1 = "40046/2/1";
-my $genome_obj_name2 = "Drosophila melanogaster";
+my $genome_obj_name2 = "Drosophila_melanogaster";
 my $genome_ref2 = "40046/3/1";
+my $genome_obj_name3 = "Nomada_ferruginata";
+my $genome_ref3 = "40046/4/1";
 
-if ($DEBUG != 'Y') {
+# PROD
+#my $genome_ref1 = "19217/183555/4";
+#my $genome_ref2 = "19217/191347/4";
+#my $genome_ref3 = "19217/165153/4";
+
+if ($DEBUG ne 'Y') {
 	my $tmp_obj;
 	$genome_obj_name1 = "Carsonella";
 	my $genome_gbff_name1 = "Carsonella.gbk";
@@ -68,19 +75,32 @@ if ($DEBUG != 'Y') {
 	$genome_obj_name2 = "Methanosarcina";
 	my $genome_gbff_name2 = "Methanosarcina_acetivorans_C2A.gbff";
 	($tmp_obj, $genome_ref2) = prepare_gbff($genome_gbff_name2,$genome_obj_name2);
+	my $genome_gbff_name3 = "GCF_000287295.1_ASM28729v1_genomic.gbff";
+	($tmp_obj, $genome_ref3) = prepare_gbff($genome_gbff_name3,$genome_obj_name3);
+	
 }
 
 my ($orig_genome1,$orig_funcs1) = &get_and_prep($genome_ref1);
 my ($orig_genome2,$orig_funcs2) = &get_and_prep($genome_ref2);
+my ($orig_genome3,$orig_funcs3) = &get_and_prep($genome_ref3);
 
+#
+#	TEST TWO GENOMES -
+#
 lives_ok {
-	my ($genome_obj,$params) = &submit_multi_annotation('multi_genomes', [$genome_ref1,$genome_ref2]);
-	my $gs = get_ws_name() . "/" . $genome_obj ;
-	my $info = $ws_client->get_objects([{ref=>$gs}])->[0]->{info};
-	my $newref = $info->[6]."/".$info->[0]."/".$info->[4];
-	# If you got this far, the new object was created.
+	if ($DEBUG ne 'Y') {
+		my ($genome_obj,$params) = &submit_multi_annotation('multi_genomes', [$genome_ref1,$genome_ref2]);
+		my $gs = get_ws_name() . "/" . $genome_obj ;
+		my $info = $ws_client->get_objects([{ref=>$gs}])->[0]->{info};
+		my $newref = $info->[6]."/".$info->[0]."/".$info->[4];
+		# If you got this far, the new object was created.
+	}
 	1;
 } "Pipeline Runs";
+
+#
+#	BUILD AND TEST A GENOME SET
+#
 
 lives_ok {
 	if ($DEBUG ne 'Y') {
@@ -103,7 +123,33 @@ lives_ok {
 		1;
 	}
 } "Pipeline Runs";
-done_testing(2);
+
+#
+#	BUILD AND TEST A GENOME SET PLUS ANOTHER GENOME
+#
+
+lives_ok {
+	if ($DEBUG eq 'Y') {
+		my $genome_set_name = 'genome_plus_set';
+		my $genome_set = $su->KButil_Build_GenomeSet({
+        	workspace_name => get_ws_name(),
+        	input_refs => [$genome_ref1,$genome_ref2],
+        	output_name => $genome_set_name,
+        	desc => 'GenomeSet Description'
+    	});
+
+		my $gs = get_ws_name() . "/" . $genome_set_name ;
+		my $info = $ws_client->get_objects([{ref=>$gs}])->[0]->{info};
+		my $newref = $info->[6]."/".$info->[0]."/".$info->[4];
+
+		my ($genome_obj,$params) = &submit_set_annotation($genome_set_name, [$newref,$genome_ref3]);
+		$info = $ws_client->get_objects([{ref=>$gs}])->[0]->{info};
+	# 	If you got this far, the new object was created.
+	} else {
+		1;
+	}
+} "Pipeline Runs";
+done_testing(3);
 
 my $err = undef;
 if ($@) {

--- a/test/my_assembly_test.pl
+++ b/test/my_assembly_test.pl
@@ -12,6 +12,9 @@ use GenomeAnnotationAPI::GenomeAnnotationAPIClient;
 use Storable qw(dclone);
 use File::Slurp;
 
+use lib "/kb/module/test";
+use testRASTutil;
+
 local $| = 1;
 my $token = $ENV{'KB_AUTH_TOKEN'};
 my $config_file = $ENV{'KB_DEPLOYMENT_CONFIG'};
@@ -22,51 +25,40 @@ my $ws_client = new Workspace::WorkspaceClient($ws_url,token => $token);
 my $call_back_url = $ENV{ SDK_CALLBACK_URL };
 my $gaa = new GenomeAnnotationAPI::GenomeAnnotationAPIClient($call_back_url);
 
-sub get_ws_name {
-    if (!defined($ws_name)) {
-        my $suffix = int(time * 1000);
-        $ws_name = 'test_RAST_SDK_' . $suffix;
-        $ws_client->create_workspace({workspace => $ws_name});
-    }
-    return $ws_name;
-}
-
-sub make_impl_call {
-    my ($method, $params) = @_;
-    # Prepare json file input
-    my $input = {
-        method => $method,
-        params => $params,
-        version => "1.1",
-        id => "1"
-    };
-    open my $fh, ">", "/kb/module/work/input.json";
-    print $fh encode_json($input);
-    close $fh;
-    my $output_path = "/kb/module/work/output.json";
-    if (-e $output_path) {
-        unlink($output_path);
-    }
-    # Run run_async.sh
-    system("sh", "/kb/module/scripts/run_async.sh");
-    # Load json file with output
-    open my $fh2, "<", $output_path;
-    my $output_json = <$fh2>;
-    #print $output_json;
-    close $fh2;
-    my $json = JSON->new;
-    my $output = $json->decode($output_json);
-    if (defined($output->{error})) {
-        die encode_json($output->{error});
-    }
-    my $ret_obj = $output->{result}->[0];
-    return $ret_obj;
+sub test_annotate_assembly {
+    my($assembly_obj_name,$genome_obj_name) = @_;
+    my $params={"input_contigset"=>$assembly_obj_name,
+             "scientific_name"=>'bogus',
+             "domain"=>'B',
+             "genetic_code"=>'11',
+             "call_features_rRNA_SEED"=>'0',
+             "call_features_tRNA_trnascan"=>'0',
+             "call_selenoproteins"=>'0',
+             "call_pyrrolysoproteins"=>'0',
+             "call_features_repeat_region_SEED"=>'0',
+             "call_features_insertion_sequences"=>'0',
+             "call_features_strep_suis_repeat"=>'0',
+             "call_features_strep_pneumo_repeat"=>'0',
+             "call_features_crispr"=>'0',
+             "call_features_CDS_glimmer3"=>'0',
+             "call_features_CDS_prodigal"=>'1',
+             "annotate_proteins_kmer_v2"=>'0',
+             "kmer_v1_parameters"=>'0',
+             "annotate_proteins_similarity"=>'0',
+             "resolve_overlapping_features"=>'0',
+             "call_features_prophage_phispy"=>'0',
+             "output_genome"=>$genome_obj_name,
+             "workspace"=>get_ws_name()
+           };
+    #$impl->annotate_genome($params);
+    my $ret = make_impl_call("RAST_SDK.annotate_genome", $params);
 }
 
 sub prepare_assembly {
     my($assembly_obj_name) = @_;
-    my $fasta_data_path = "/kb/module/test/data/Clostridium_thermocellum_ATCC27405.fa";
-    my $fasta_temp_path = "/kb/module/work/tmp/bogus.fna";
+    #my $fasta_data_path = "/kb/module/test/data/Clostridium_thermocellum_ATCC27405.fa";
+    my $fasta_data_path = "/kb/module/test/data/$assembly_obj_name";
+    my $fasta_temp_path = "/kb/module/work/tmp/$assembly_obj_name";
     copy $fasta_data_path, $fasta_temp_path;
     my $call_back_url = $ENV{ SDK_CALLBACK_URL };
     my $au = new AssemblyUtil::AssemblyUtilClient($call_back_url);
@@ -89,61 +81,20 @@ sub check_genome_obj {
     ok(scalar @{ $genome_obj->{mrnas} } gt 0, "Number of mRNAs");
 }
 
-sub test_annotate_assembly {
-    my($assembly_obj_name) = @_;
-    my $genome_obj_name = "genome.1";
-    my $params={"input_contigset"=>$assembly_obj_name,
-             "scientific_name"=>'bogus',
-             "domain"=>'B',
-             "genetic_code"=>'11',
-             "call_features_rRNA_SEED"=>'0',
-             "call_features_tRNA_trnascan"=>'1',
-             "call_selenoproteins"=>'0',
-             "call_pyrrolysoproteins"=>'0',
-             "call_features_repeat_region_SEED"=>'0',
-             "call_features_insertion_sequences"=>'0',
-             "call_features_strep_suis_repeat"=>'0',
-             "call_features_strep_pneumo_repeat"=>'0',
-             "call_features_crispr"=>'0',
-             "call_features_CDS_glimmer3"=>'0',
-             "call_features_CDS_prodigal"=>'1',
-             "annotate_proteins_kmer_v2"=>'1',
-             "kmer_v1_parameters"=>'0',
-             "annotate_proteins_similarity"=>'0',
-             "resolve_overlapping_features"=>'0',
-             "call_features_prophage_phispy"=>'0',
-             "output_genome"=>$genome_obj_name,
-             "workspace"=>get_ws_name()
-           };
-    #$impl->annotate_genome($params);
-    my $ret = make_impl_call("RAST_SDK.annotate_genome", $params);
-    my $genome_ref = get_ws_name() . "/" . $genome_obj_name;
-    my $genome_obj = $ws_client->get_objects([{ref=>$genome_ref}])->[0]->{data};
-    open my $fh, ">", "/kb/module/work/tmp/bogus_genome.json";
-    print $fh encode_json($genome_obj);
-    close $fh;
-    # no detailed checking right now
-    check_genome_obj($genome_obj);
-}
-
-
-sub save_genome_to_ws {
-    my($genome_obj,$genome_obj_name) = @_;
-    #my $ret = $ws_client->save_objects({workspace=>get_ws_name(),objects=>[{data=>$genome_obj,
-    #        type=>"KBaseGenomes.Genome-11.0", name=>$genome_obj_name}]})->[0];
-    my $ret = $gaa->save_one_genome_v1({workspace=>get_ws_name(), data=>$genome_obj, name=>$genome_obj_name})->{info};
-    return $ret->[6]."/".$ret->[0]."/".$ret->[4];
-}
-
-
-
-
-my $assembly_obj_name = "contigset.1";
+my $assembly_obj_name = "bogus.fna";
 my $assembly_ref = prepare_assembly($assembly_obj_name);
+my $genome_obj_name = 'annotated_genome';
 my $genome_ref_new;
 my $genome_ref_old;
 lives_ok {
-        test_annotate_assembly($assembly_obj_name);
+    test_annotate_assembly($assembly_obj_name,$genome_obj_name);
+    my $genome_ref = get_ws_name() . "/" . $genome_obj_name;
+    my $genome_obj = $ws_client->get_objects([{ref=>$genome_ref}])->[0]->{data};
+#    open my $fh, ">", "/kb/module/work/tmp/bogus_genome.json";
+#    print $fh encode_json($genome_obj);
+#    close $fh;
+    # no detailed checking right now
+    check_genome_obj($genome_obj);
     }, "test_annotate_assembly";
 print "Summary for $assembly_obj_name\n";
 done_testing(7);

--- a/ui/narrative/methods/annotate_contigsets/spec.json
+++ b/ui/narrative/methods/annotate_contigsets/spec.json
@@ -56,6 +56,12 @@
           "display": "A (Archaea)",
           "id": "fast",
           "ui_name": "A (Archaea)"
+        },
+        {
+          "value": "U",
+          "display": "U (Unknown)",
+          "id": "fast",
+          "ui_name": "U (Unknown)"
         }
       ]
     }


### PR DESCRIPTION
1. Fix some minor bugs that showed up when testing the last merge. Reports for multiple genomes and multiple assemblies are not yet in the right place.

2. Now that the Impl file prevents execution of tools that can't deal with an unknown domain, it is now okay for the domain to be unknown. (update to the spec.json file).  This will be applicable to assemblies from metagenomes/bins that may not be strictly from one genome. Once updates to kb_seed are released, Prodigal will have a flag that is appropriate for mixed assemblies. 

3. There was a typo in genetic_code (it is not genetic_name).

4. Make updates to the tests.
@JamesJeffryes 