### PR TITLE
Redundancy, extra keys, output genomeSet name

### DIFF
--- a/ui/narrative/methods/annotate_contigsets/spec.json
+++ b/ui/narrative/methods/annotate_contigsets/spec.json
@@ -255,7 +255,7 @@
     }  
   }, {
     "id": "output_genome",
-    "optional": true,
+    "optional": false,
     "advanced": false,
     "allow_multiple": false,
     "default_values": [ "" ],

--- a/ui/narrative/methods/reannotate_microbial_genomes/spec.json
+++ b/ui/narrative/methods/reannotate_microbial_genomes/spec.json
@@ -207,7 +207,7 @@
     }  
   }, {
     "id": "output_genome",
-    "optional": true,
+    "optional": false,
     "advanced": false,
     "allow_multiple": false,
     "default_values": [ "" ],


### PR DESCRIPTION
There changes requested by Dylan and Jason:

1. Catch redundant genomes/assemblies when annotating multiples. Warn the user that the redundancy was only annotated once.
2. Jason requested that type and protein_md5 no longer be included as part of the genome features.
3. When doing multiple genomes or assemblies, the resulting output genomeSet name is now mandatory. It was creating odd names that were confusing.
4. The tests haven't been updated yet because I ran out of time for the GSP.
@JamesJeffryes 
