### PR TITLE
updated kmer data

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -18,7 +18,7 @@ elif [ "${1}" = "async" ] ; then
 elif [ "${1}" = "init" ] ; then
   echo "Initialize module"
   cd /data
-  curl -s http://bioseed.mcs.anl.gov/~chenry/kmer.tgz|tar xzf -
+  curl -s http://bioseed.mcs.anl.gov/~qzhang/kmer_classification/kmer.tgz|tar xzf -
   ln -s /data/kmer/Release70 /data/kmer/ACTIVE/Release70
   ln -s /data/kmer/Release70 /data/kmer/DEFAULT
   if [ -d kmer ] ; then

--- a/ui/narrative/methods/reannotate_microbial_genome/display.yaml
+++ b/ui/narrative/methods/reannotate_microbial_genome/display.yaml
@@ -216,7 +216,7 @@ description : |
     <p><strong>Team members who developed & deployed algorithm in KBase:</strong>
     Thomas Brettin, James Davis, Terry Disz, Robert Edwards, Chris Henry, Gary Olsen, Robert Olson, Ross Overbeek, Bruce Parrello, Gordon Pusch, Roman Sutormin, and Fangfang Xia. For questions, please <a href=”http://kbase.us/contact-us/”>contact us</a>.</p>
 
-   <p><b><i>The authors of RAST request that if you use the results of this annotation in your work, please cite the first three listed publications:</i></b></p>
+    <p><b><i>The authors of RAST request that if you use the results of this annotation in your work, please cite the first three listed publications:</i></b></p>
 
 
 


### PR DESCRIPTION
The kmer data is updated outside of the codebase.  The only change in the code is at 
https://github.com/kbaseapps/RAST_SDK/blob/master/scripts/entrypoint.sh#L21
where I replaced "http://bioseed.mcs.anl.gov/~chenry/kmer.tgz" with "http://bioseed.mcs.anl.gov/~qzhang/kmer_classification/kmer.tgz

A space is also added in front of a line started with "<p><b><i>The authors of RAST request..." in ui/narrative/methods/reannotate_microbial_genome/display.yaml
to avoid a kb-test validation error.