### PR TITLE
added checking on /data/kmer/V2Data to ensure kmer data is extracted

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -21,7 +21,7 @@ elif [ "${1}" = "init" ] ; then
   curl -s http://bioseed.mcs.anl.gov/~qzhang/kmer_classification/kmer.tgz|tar xzf -
   ln -s /data/kmer/Release70 /data/kmer/ACTIVE/Release70
   ln -s /data/kmer/Release70 /data/kmer/DEFAULT
-  if [ -d kmer ] ; then
+  if [ -d kmer/V2Data ] ; then
   	touch __READY__
   else
     echo "Init failed"


### PR DESCRIPTION
On line 24, change 'if [ -d kmer ] ; then' to 'if [ -d kmer/V2Data ] ; then`. 

Explanation: I noticed that in the Dockerfile, on line 64, command 'mkdir /data/kmer' created the directory '/data/kmer'.   Then in the 'entrypoint.sh' line 24, it checks if (under /data) 'kmer' is a directory.  The check will always be true!  As a result, the module will always be '__READY' even though the refdata downloading and untarring is not complete yet.

