### PR TITLE
use dynamic dropdown for sci name select

### DIFF
--- a/ui/narrative/methods/annotate_contigset/spec.json
+++ b/ui/narrative/methods/annotate_contigset/spec.json
@@ -19,12 +19,30 @@
       "valid_ws_types" : [ "KBaseGenomes.ContigSet","KBaseGenomeAnnotations.Assembly" ]
     }
   }, {
-    "id" : "scientific_name",
-    "optional" : false,
-    "advanced" : false,
-    "allow_multiple" : false,
-    "default_values" : [ "" ],
-    "field_type" : "text"
+    "id": "scientific_name",
+    "optional": false,
+    "advanced": false,
+    "allow_multiple": false,
+    "default_values": [""],
+    "field_type": "dynamic_dropdown",
+    "dynamic_dropdown_options": {
+        "data_source": "custom",
+        "service_function": "taxonomy_re_api.search_taxa",
+        "service_version": "dev",
+        "service_params": [
+            {
+                "search_text": "prefix:{{dynamic_dropdown_input}}",
+                "ns": "ncbi_taxonomy",
+                "limit": 1000
+            }
+        ],
+        "query_on_empty_input": 0,
+        "result_array_index": 0,
+        "path_to_selection_items": ["results"],
+        "selection_id": "scientific_name",
+        "description_template": "Tax ID {{ncbi_taxon_id}}:&nbsp<strong>{{scientific_name}}</strong>",
+        "multiselection": false
+    }
   }, {
     "id" : "domain",
     "optional" : false,

--- a/ui/narrative/methods/annotate_contigsets/spec.json
+++ b/ui/narrative/methods/annotate_contigsets/spec.json
@@ -30,12 +30,30 @@
             "n_rows" : 10
     	}
   }, {
-    "id" : "scientific_name",
-    "optional" : true,
-    "advanced" : true,
-    "allow_multiple" : false,
-    "default_values" : [ "unknown taxon" ],
-    "field_type" : "text"
+    "id": "scientific_name",
+    "optional": true,
+    "advanced": true,
+    "allow_multiple": false,
+    "default_values": ["unknown taxon"],
+    "field_type": "dynamic_dropdown",
+    "dynamic_dropdown_options": {
+        "data_source": "custom",
+        "service_function": "taxonomy_re_api.search_taxa",
+        "service_version": "dev",
+        "service_params": [
+            {
+                "search_text": "prefix:{{dynamic_dropdown_input}}",
+                "ns": "ncbi_taxonomy",
+                "limit": 1000
+            }
+        ],
+        "query_on_empty_input": 0,
+        "result_array_index": 0,
+        "path_to_selection_items": ["results"],
+        "selection_id": "scientific_name",
+        "description_template": "Tax ID {{ncbi_taxon_id}}:&nbsp<strong>{{scientific_name}}</strong>",
+        "multiselection": false
+    }
   }, {
     "id" : "domain",
     "optional" : true,


### PR DESCRIPTION
Requires: https://github.com/kbase/narrative/pull/1519

A few points:

- it's not clear to me that the RE query sorts the results by relevance.
  Probably need to look into that.
- Currently the tax api is only available at the dev endpoint. That needs to
  be changed before production.
- This can't be fully tested until after the app is deployed.
- Currently the widget just sends the sci name as it can only send one string
  value. Changing that to a tax ID would break the app. The current fix,
  at least, will ensure the genome is linked to an existing taxa.
- There is limited potential to format the contents of the drop down. I tried
  a multi line approach but the contents overlap.
- annotate_contigset requires a genome name, while annotate_contigsets does
  not. Should that change? Also for the latter it's an advanced option and
   defaults to unknown taxon.