### PR TITLE
Added one line 'my $gaserv = Bio::KBase::GenomeAnnotation::GenomeAnnotationImpl->new();' in RAST_SDKImpl.pm on line 1672.

### DIFF
--- a/lib/RAST_SDK/RAST_SDKImpl.pm
+++ b/lib/RAST_SDK/RAST_SDKImpl.pm
@@ -1668,6 +1668,8 @@ sub annotate_proteins
     			protein_translation => $params->{proteins}->[$i]
     		});
     }
+
+    my $gaserv = Bio::KBase::GenomeAnnotation::GenomeAnnotationImpl->new();
     my $genome = $gaserv->run_pipeline($inputgenome,[
 		{ name => 'annotate_proteins_kmer_v2', kmer_v2_parameters => {} },
 		#{ name => 'annotate_proteins_kmer_v1', kmer_v1_parameters => { annotate_hypothetical_only => 1 } },

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -18,13 +18,18 @@ elif [ "${1}" = "async" ] ; then
 elif [ "${1}" = "init" ] ; then
   echo "Initialize module"
   cd /data
-  curl -s http://bioseed.mcs.anl.gov/~qzhang/kmer_classification/kmer.tgz|tar xzf -
-  ln -s /data/kmer/Release70 /data/kmer/ACTIVE/Release70
-  ln -s /data/kmer/Release70 /data/kmer/DEFAULT
-  if [ -d kmer/V2Data ] ; then
-  	touch __READY__
-  else
-    echo "Init failed"
+  curl -s http://bioseed.mcs.anl.gov/~qzhang/kmer_classification/kmer.tgz.md5 -o kmer.tgz.md5
+  curl -s http://bioseed.mcs.anl.gov/~qzhang/kmer_classification/kmer.tgz -o kmer.tgz
+  if [ md5sum -c kmer.tgz.md5 ] ; then
+        tar xzf kmer.tgz -
+        ln -s /data/kmer/Release70 /data/kmer/ACTIVE/Release70
+        ln -s /data/kmer/Release70 /data/kmer/DEFAULT
+        if [ -d kmer/V2Data ] ; then
+            touch __READY__
+        else
+	    echo "Init failed"
+        fi
+        rm kmer.tgz kmer.tgz.md5
   fi
 elif [ "${1}" = "bash" ] ; then
   bash

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -18,8 +18,8 @@ elif [ "${1}" = "async" ] ; then
 elif [ "${1}" = "init" ] ; then
   echo "Initialize module"
   cd /data
-  curl -s http://bioseed.mcs.anl.gov/~qzhang/kmer_classification/kmer.tgz.md5 -o kmer.tgz.md5
-  curl -s http://bioseed.mcs.anl.gov/~qzhang/kmer_classification/kmer.tgz -o kmer.tgz
+  curl -s http://bioseed.mcs.anl.gov/~qzhang/kmer_classification/core.2019-0712/kmer.tgz.md5 -o kmer.tgz.md5
+  curl -s http://bioseed.mcs.anl.gov/~qzhang/kmer_classification/core.2019-0712/kmer.tgz -o kmer.tgz
   wait
   if [ md5sum -c kmer.tgz.md5 ] ; then
         tar xzf kmer.tgz -

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -20,6 +20,7 @@ elif [ "${1}" = "init" ] ; then
   cd /data
   curl -s http://bioseed.mcs.anl.gov/~qzhang/kmer_classification/kmer.tgz.md5 -o kmer.tgz.md5
   curl -s http://bioseed.mcs.anl.gov/~qzhang/kmer_classification/kmer.tgz -o kmer.tgz
+  wait
   if [ md5sum -c kmer.tgz.md5 ] ; then
         tar xzf kmer.tgz -
         ln -s /data/kmer/Release70 /data/kmer/ACTIVE/Release70


### PR DESCRIPTION
Somehow my one-line addition to the RAST_SDKImpl.pm (line 1672) on Aug. 22, 2019 was lost.  Because of that, the current dev deployment is erroring: 

Global symbol "$gaserv" requires explicit package name at /kb/module/bin/../lib/RAST_SDK/RAST_SDKImpl.pm line 1671, <DATA> line 217.
Compilation failed in require at /kb/module/bin/../lib/RAST_SDK/RAST_SDKServer.pm line 727, <DATA> line 217.
BEGIN failed--compilation aborted at /kb/module/bin/../lib/RAST_SDK/RAST_SDKServer.pm line 727, <DATA> line 217.
xargs: sh: exited with status 255; aborting
Docker Container id 47f46228ecedbba782a0def6b31cbc467fe56aa61b1fb64b975320768abf8852 will automatically timeout in 604800 seconds
Fatal error: java.lang.IllegalStateException: Output file is not found, exit code is 124 at us.kbase.narrativejobservice.sdkjobs.DockerRunner.run(DockerRunner.java:362) at us.kbase.narrativejobservice.sdkjobs.SDKLocalMethodRunner.main(SDKLocalMethodRunner.java:644)