### PR TITLE
Pass taxon ID vs sci name to annotate_genomes(s)

### DIFF
--- a/RAST_SDK.spec
+++ b/RAST_SDK.spec
@@ -24,12 +24,24 @@ module RAST_SDK {
 	*/
 	typedef string workspace_name;
 	
+	/* Parameters for the annotate_genome method.
+
+		ncbi_taxon_id - the numeric ID of the NCBI taxon to which this genome belongs. If this
+			is included scientific_name is ignored.
+		relation_engine_timestamp_ms - the timestamp to send to the Relation Engine when looking
+			up taxon information in milliseconds since the epoch.
+		scientific_name - the scientific name of the genome. Overridden by ncbi_taxon_id.
+
+		TODO: document remainder of parameters.
+	*/
 	typedef structure {
 	    string workspace;
 	    genome_id input_genome;
 	    contigset_id input_contigset;
 	    int genetic_code;
 	    string domain;
+		int ncbi_taxon_id;
+		int relation_engine_timestamp_ms;
 	    string scientific_name;
 	    string output_genome;
 	    bool call_features_rRNA_SEED;
@@ -74,11 +86,23 @@ module RAST_SDK {
 	    string scientific_name;
 	} GenomeParams;
 	
+	/* Parameters for the annotate_genomes method.
+
+		ncbi_taxon_id - the numeric ID of the NCBI taxon to which this genome belongs. If this
+			is included scientific_name is ignored.
+		relation_engine_timestamp_ms - the timestamp to send to the Relation Engine when looking
+			up taxon information in milliseconds since the epoch.
+		scientific_name - the scientific name of the genome. Overridden by ncbi_taxon_id.
+		
+		TODO: document remainder of parameters.
+	*/
 	typedef structure {
 	    string workspace;
 	    list<GenomeParams> input_genomes;
 		int genetic_code;
 		string domain;
+		int ncbi_taxon_id;
+		int relation_engine_timestamp_ms;
 	    string scientific_name;
 		string genome_text;
 	    string output_genome;

--- a/RAST_SDK.spec
+++ b/RAST_SDK.spec
@@ -5,9 +5,9 @@ This wraps genome_annotation which is based off of the SEED annotations.
 
 module RAST_SDK {
 	/*
-        A binary boolean
-    */
-    typedef int bool;
+		A binary boolean
+	*/
+	typedef int bool;
 	
 	/*
 		A string representing a genome id.
@@ -35,40 +35,40 @@ module RAST_SDK {
 		TODO: document remainder of parameters.
 	*/
 	typedef structure {
-	    string workspace;
-	    genome_id input_genome;
-	    contigset_id input_contigset;
-	    int genetic_code;
-	    string domain;
+		string workspace;
+		genome_id input_genome;
+		contigset_id input_contigset;
+		int genetic_code;
+		string domain;
 		int ncbi_taxon_id;
 		int relation_engine_timestamp_ms;
-	    string scientific_name;
-	    string output_genome;
-	    bool call_features_rRNA_SEED;
-	    bool call_features_tRNA_trnascan;
-	    bool call_selenoproteins;
-	    bool call_pyrrolysoproteins;
-	    bool call_features_repeat_region_SEED;
-	    bool call_features_insertion_sequences;
-	    bool call_features_strep_suis_repeat;
-	    bool call_features_strep_pneumo_repeat;
-	    bool call_features_crispr;
-	    bool call_features_CDS_glimmer3;
-	    bool call_features_CDS_prodigal;
-	    bool call_features_CDS_genemark;
-	    bool annotate_proteins_kmer_v2;
-	    bool kmer_v1_parameters;
-	    bool annotate_proteins_similarity;
-	    bool resolve_overlapping_features;
-	    bool call_features_prophage_phispy;
-	    bool retain_old_anno_for_hypotheticals;
+		string scientific_name;
+		string output_genome;
+		bool call_features_rRNA_SEED;
+		bool call_features_tRNA_trnascan;
+		bool call_selenoproteins;
+		bool call_pyrrolysoproteins;
+		bool call_features_repeat_region_SEED;
+		bool call_features_insertion_sequences;
+		bool call_features_strep_suis_repeat;
+		bool call_features_strep_pneumo_repeat;
+		bool call_features_crispr;
+		bool call_features_CDS_glimmer3;
+		bool call_features_CDS_prodigal;
+		bool call_features_CDS_genemark;
+		bool annotate_proteins_kmer_v2;
+		bool kmer_v1_parameters;
+		bool annotate_proteins_similarity;
+		bool resolve_overlapping_features;
+		bool call_features_prophage_phispy;
+		bool retain_old_anno_for_hypotheticals;
 	} AnnotateGenomeParams;
 	
 	typedef structure {
-	    workspace_name workspace;
-	    string id;
-	    string report_name;
-        string report_ref;
+		workspace_name workspace;
+		string id;
+		string report_name;
+		string report_ref;
 	} AnnotateGenomeResults;
 	
 	/*
@@ -83,7 +83,7 @@ module RAST_SDK {
 		genome_id output_genome;
 		int genetic_code;
 		string domain;
-	    string scientific_name;
+		string scientific_name;
 	} GenomeParams;
 	
 	/* Parameters for the annotate_genomes method.
@@ -97,39 +97,39 @@ module RAST_SDK {
 		TODO: document remainder of parameters.
 	*/
 	typedef structure {
-	    string workspace;
-	    list<GenomeParams> input_genomes;
+		string workspace;
+		list<GenomeParams> input_genomes;
 		int genetic_code;
 		string domain;
 		int ncbi_taxon_id;
 		int relation_engine_timestamp_ms;
-	    string scientific_name;
+		string scientific_name;
 		string genome_text;
-	    string output_genome;
-	    bool call_features_rRNA_SEED;
-	    bool call_features_tRNA_trnascan;
-	    bool call_selenoproteins;
-	    bool call_pyrrolysoproteins;
-	    bool call_features_repeat_region_SEED;
-	    bool call_features_insertion_sequences;
-	    bool call_features_strep_suis_repeat;
-	    bool call_features_strep_pneumo_repeat;
-	    bool call_features_crispr;
-	    bool call_features_CDS_glimmer3;
-	    bool call_features_CDS_prodigal;
-	    bool call_features_CDS_genemark;
-	    bool annotate_proteins_kmer_v2;
-	    bool kmer_v1_parameters;
-	    bool annotate_proteins_similarity;
-	    bool resolve_overlapping_features;
-	    bool call_features_prophage_phispy;
-	    bool retain_old_anno_for_hypotheticals;
+		string output_genome;
+		bool call_features_rRNA_SEED;
+		bool call_features_tRNA_trnascan;
+		bool call_selenoproteins;
+		bool call_pyrrolysoproteins;
+		bool call_features_repeat_region_SEED;
+		bool call_features_insertion_sequences;
+		bool call_features_strep_suis_repeat;
+		bool call_features_strep_pneumo_repeat;
+		bool call_features_crispr;
+		bool call_features_CDS_glimmer3;
+		bool call_features_CDS_prodigal;
+		bool call_features_CDS_genemark;
+		bool annotate_proteins_kmer_v2;
+		bool kmer_v1_parameters;
+		bool annotate_proteins_similarity;
+		bool resolve_overlapping_features;
+		bool call_features_prophage_phispy;
+		bool retain_old_anno_for_hypotheticals;
 	} AnnotateGenomesParams;
 	
 	typedef structure {
-	    workspace_name workspace;
-	    string report_name;
-        string report_ref;
+		workspace_name workspace;
+		string report_name;
+		string report_ref;
 	} AnnotateGenomesResults;
 	
 	/*
@@ -143,7 +143,7 @@ module RAST_SDK {
 	} AnnotateProteinParams;
 	
 	typedef structure {
-	    list<list<string> > functions;
+		list<list<string> > functions;
 	} AnnotateProteinResults;
 	
 	/*

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
 ### OVERVIEW
 This module wraps the RAST annotation pipeline for KBase.
 
+### Version 0.1.6
+__Changes__
+annotate_genome(s) now takes a taxon ID and timestamp to allow exact specification of the taxon ID
+rather than submitting a scientific name. The scientific name is retrieved from the Relation
+Engine using the timestamp.
+
 ### Version 0.1.5
 __Changes__
 Prepended the scientific name display in the UI with NCBI.

--- a/deploy.cfg
+++ b/deploy.cfg
@@ -17,6 +17,7 @@ auth-service-url = {{ auth_service_url }}
 {% if auth_service_url_allow_insecure %}
 auth-service-url-allow-insecure = {{ auth_service_url_allow_insecure }}
 {% endif %}
+relation-engine-url = {{ kbase_endpoint }}/relation_engine_api
 scratch = /kb/module/work/tmp
 
 [UtilConfig]

--- a/kbase.yml
+++ b/kbase.yml
@@ -10,10 +10,10 @@ service-language:
     perl
 
 module-version:
-    0.1.5
+    0.1.6
 
 owners:
-    [chenry,scanon,olson,jjeffryes,umaganapathyswork,landml, gaprice]
+    [chenry,scanon,olson,jjeffryes,umaganapathyswork,landml,gaprice]
 
 data-version:
     0.4

--- a/lib/RAST_SDK/RAST_SDKImpl.pm
+++ b/lib/RAST_SDK/RAST_SDKImpl.pm
@@ -1066,7 +1066,7 @@ sub get_scientific_name_for_NCBI_taxon {
     my $url = $self->{_re_url} . "/api/v1/query_results?stored_query=ncbi_fetch_taxon";
     my $content = encode_json({
         'ts' => $timestamp,
-        'id'=> $tax_id
+        'id'=> $tax_id . '' # make sure tax id is a string
         });
     my $req = HTTP::Request->new(POST => $url);
     $req->header('content-type', 'application/json');
@@ -1083,7 +1083,7 @@ sub get_scientific_name_for_NCBI_taxon {
     my $retjsonref = $ret->decoded_content({'raise_error' => 1, 'ref' => 1});
     my $retjson = decode_json($retjsonref);
 
-    if (!$retjson->count) {
+    if (!$retjson->{count}) {
         die "No result from Relation Engine for NCBI taxonomy ID " . $tax_id;
     }
     return $retjson->{'results'}[0]{'scientific_name'};

--- a/lib/RAST_SDK/RAST_SDKImpl.pm
+++ b/lib/RAST_SDK/RAST_SDKImpl.pm
@@ -1549,6 +1549,8 @@ sub annotate_genomes
 		my $list = [qw(
 			workspace
 			scientific_name
+			ncbi_taxon_id
+			relation_engine_timestamp_ms
 			genetic_code
 			domain
 			call_features_rRNA_SEED

--- a/lib/RAST_SDK/RAST_SDKImpl.pm
+++ b/lib/RAST_SDK/RAST_SDKImpl.pm
@@ -183,7 +183,7 @@ sub annotate_process {
   		features => []
   	};
 	if ($parameters->{ncbi_taxon_id}) {
-		$inputgenome->{taxon_assignments} = {'ncbi' => "" . $parameters->{ncbi_taxon_id}};
+		$inputgenome->{taxon_assignments} = {'ncbi' => '' . $parameters->{ncbi_taxon_id}};
 	}
   	my $contigobj;
   	my $message = "";
@@ -1075,6 +1075,9 @@ sub get_scientific_name_for_NCBI_taxon {
     
     my $ret = $ua->request($req);
     if (!$ret->is_success()) {
+		print("Error body from Relation Engine on NCBI taxa query:\n" .
+			$ret->decoded_content({'raise_error' => 1}));
+		# might want to try to parse content to json and extract error, try this for now
         die "Error contacting Relation Engine: " . $ret->status_line();
     }
     my $retjsonref = $ret->decoded_content({'raise_error' => 1, 'ref' => 1});

--- a/lib/RAST_SDK/RAST_SDKImpl.pm
+++ b/lib/RAST_SDK/RAST_SDKImpl.pm
@@ -1097,12 +1097,12 @@ sub new
     };
     bless $self, $class;
     #BEGIN_CONSTRUCTOR
-	my $cfg = Bio::KBase::utilities::read_config({
+	Bio::KBase::utilities::read_config({
 		service => "RAST_SDK",
 		mandatory => ['workspace-url', 'relation-engine-url']
 	});
-	# check this. Probably need to print cfg
-	$self->{_re_url} = $cfg->{'relation-engine-url'};
+	$self->{_re_url} = Bio::KBase::utilities::conf(
+		$ENV{KB_SERVICE_NAME} or "RAST_SDK", "relation-engine-url");
 	# TODO check url is ok by querying RE root
 
     #END_CONSTRUCTOR

--- a/lib/RAST_SDK/RAST_SDKImpl.pm
+++ b/lib/RAST_SDK/RAST_SDKImpl.pm
@@ -1075,9 +1075,9 @@ sub get_scientific_name_for_NCBI_taxon {
     
     my $ret = $ua->request($req);
     if (!$ret->is_success()) {
-		print("Error body from Relation Engine on NCBI taxa query:\n" .
-			$ret->decoded_content({'raise_error' => 1}));
-		# might want to try to parse content to json and extract error, try this for now
+        print("Error body from Relation Engine on NCBI taxa query:\n" .
+            $ret->decoded_content({'raise_error' => 1}));
+        # might want to try to parse content to json and extract error, try this for now
         die "Error contacting Relation Engine: " . $ret->status_line();
     }
     my $retjsonref = $ret->decoded_content({'raise_error' => 1, 'ref' => 1});

--- a/test/my_assembly_test.pl
+++ b/test/my_assembly_test.pl
@@ -43,6 +43,7 @@ my $params={"input_contigset"=>$assembly_obj_name,
 
 $params = &set_params($genome_obj_name,$params);
 
+# Test processing a single assembly and saving as a genome.
 lives_ok {
 	print("######## Running RAST annotation ########\n");
 	my $ret = &make_impl_call("RAST_SDK.annotate_genome", $params);
@@ -63,9 +64,7 @@ lives_ok {
 }, "test_annotate_assembly";
 print "Summary for $assembly_obj_name\n";
 
-#
-#	TEST ONE ASSEMBLY -
-#
+# Test processing a single assembly and saving as a genome set.
 print "ASSEMBLYREF = $assembly_ref\n";
 lives_ok {
 
@@ -78,6 +77,10 @@ lives_ok {
 	my $data = $ws_client->get_objects([{ref=>$genome_set_obj}])->[0]->{refs};
 	my $number_genomes = scalar @{ $data};
     ok($number_genomes == 1, "Input: One Assembly. Output: $number_genomes in output GenomeSet");
+    
+    my $genome_obj = $ws_client->get_objects([{ref=>$data->[0]}])->[0]->{data};
+    ok($genome_obj->{scientific_name} eq "unknown taxon", "Sci name is correct");
+    ok(!defined($genome_obj->{taxon_assignments}), "Taxon assignments is undefined");
 
 	my $report = "/kb/module/work/tmp/annotation_report.$genome_set_name";
 	my $local_path = "/kb/module/test/report_output/annotation_report.$genome_set_name";
@@ -85,7 +88,7 @@ lives_ok {
 
 	ok(-e $local_path,'File found');
 } "Create a Report";
-done_testing(12);
+done_testing(14);
 
 my $err = undef;
 if ($@) {

--- a/test/my_assembly_test.pl
+++ b/test/my_assembly_test.pl
@@ -58,6 +58,8 @@ lives_ok {
     ok(scalar @{ $genome_obj->{cdss} } gt 0, "Number of CDSs");
     ok(defined($genome_obj->{mrnas}), "mRNAs array is present");
     ok(scalar @{ $genome_obj->{mrnas} } gt 0, "Number of mRNAs");
+    ok($genome_obj->{scientific_name} eq "Acidilobus sp 7", "Sci name is correct");
+    ok(!defined($genome_obj->{taxon_assignments}), "Taxon assignments is undefined");
 }, "test_annotate_assembly";
 print "Summary for $assembly_obj_name\n";
 
@@ -83,7 +85,7 @@ lives_ok {
 
 	ok(-e $local_path,'File found');
 } "Create a Report";
-done_testing(10);
+done_testing(12);
 
 my $err = undef;
 if ($@) {

--- a/test/my_assembly_test.pl
+++ b/test/my_assembly_test.pl
@@ -1,5 +1,6 @@
 use strict;
 use Data::Dumper;
+use Test::Deep;
 use Test::More;
 use Test::Exception;
 use Config::Simple;
@@ -17,7 +18,10 @@ use testRASTutil;
 
 print "PURPOSE:\n";
 print "    1.  Test annotation of one small assembly. \n";
-print "    2.  Test that the saved genome isn't using defaults. Must be Archaea and genetic code 4\n\n";
+print "    2.  Test that the saved genome isn't using defaults. Must be Archaea and genetic code 4\n";
+print "    3.  Test passing a taxon ID vs. a scientific name.\n";
+print "    4.  Test 2 failure modes for contacting the RE.\n";
+print "\n";
 
 local $| = 1;
 my $token = $ENV{'KB_AUTH_TOKEN'};
@@ -64,6 +68,35 @@ lives_ok {
 }, "test_annotate_assembly";
 print "Summary for $assembly_obj_name\n";
 
+# Test processing a single assembly and saving as a genome while specifing a NCBI taxon ID.
+lives_ok {
+	print("######## Running RAST annotation with Taxon ID ########\n");
+    my $params_copy = { %$params };
+    # this tax ID's species name changed in the 2018-12 NCBI dump and again in the 2019-02 dump
+    # so it is a good test case for making sure the timestamp is passed to the RE correctly.
+    # It depends on the RE containing 2018 NCBI data, which it currently does
+    $params_copy->{ncbi_taxon_id} = 2448083;  # spec says this must be a string, we're sloppy tho
+    $params_copy->{relation_engine_timestamp_ms} = 1545000000000;  # epoch ms
+
+	my $ret = &make_impl_call("RAST_SDK.annotate_genome", $params_copy);
+	my $genome_ref = get_ws_name() . "/" . $genome_obj_name;
+	my $genome_obj = $ws_client->get_objects([{ref=>$genome_ref}])->[0]->{data};
+    
+	print "\n\nOUTPUT OBJECT DOMAIN = $genome_obj->{domain}\n";
+	print "OUTPUT OBJECT G_CODE = $genome_obj->{genetic_code}\n";
+
+    ok(defined($genome_obj->{features}), "Features array is present");
+    ok(scalar @{ $genome_obj->{features} } gt 0, "Number of features");
+    ok(defined($genome_obj->{cdss}), "CDSs array is present");
+    ok(scalar @{ $genome_obj->{cdss} } gt 0, "Number of CDSs");
+    ok(defined($genome_obj->{mrnas}), "mRNAs array is present");
+    ok(scalar @{ $genome_obj->{mrnas} } gt 0, "Number of mRNAs");
+    ok($genome_obj->{scientific_name} eq "Metarhizium sp. MJH 2018c", "Sci name is correct");
+    cmp_deeply($genome_obj->{taxon_assignments}, {'ncbi' => '2448083'},
+        "Taxon assignments is correct");
+}, "test_annotate_assembly";
+print "Summary for $assembly_obj_name\n";
+
 # Test processing a single assembly and saving as a genome set.
 print "ASSEMBLYREF = $assembly_ref\n";
 lives_ok {
@@ -88,7 +121,7 @@ lives_ok {
 
 	ok(-e $local_path,'File found');
 } "Create a Report";
-done_testing(14);
+done_testing(23);
 
 my $err = undef;
 if ($@) {

--- a/test/my_assembly_test.pl
+++ b/test/my_assembly_test.pl
@@ -74,7 +74,7 @@ lives_ok {
     # this tax ID's species name changed in the 2018-12 NCBI dump and again in the 2019-02 dump
     # so it is a good test case for making sure the timestamp is passed to the RE correctly.
     # It depends on the RE containing 2018 NCBI data, which it currently does
-    $params_copy->{ncbi_taxon_id} = 2448083;  # spec says this must be a string, we're sloppy tho
+    $params_copy->{ncbi_taxon_id} = 2448083;
     $params_copy->{relation_engine_timestamp_ms} = 1545000000000;  # epoch ms
 
 	my $ret = &make_impl_call("RAST_SDK.annotate_genome", $params_copy);
@@ -138,7 +138,7 @@ lives_ok {
                 # the 2019-02 dump so it is a good test case for making sure the timestamp
                 # is passed to the RE correctly. It depends on the RE containing 2018 NCBI
                 # data, which it currently does
-                "ncbi_taxon_id"=>2448083,  # spec says this must be a string, we're sloppy tho
+                "ncbi_taxon_id"=>2448083,
                 "relation_engine_timestamp_ms"=>1545000000000  # epoch ms
                 };
 
@@ -168,7 +168,7 @@ lives_ok {
 lives_ok {
     print("######## Running RAST annotation fail with bad RE input ########\n");
     my $params_copy = { %$params };
-    $params_copy->{ncbi_taxon_id} = '32'; 
+    $params_copy->{ncbi_taxon_id} = 32; 
     $params_copy->{relation_engine_timestamp_ms} = 'Sept 19 2020';  # oops
     eval {
         &make_impl_call("RAST_SDK.annotate_genome", $params_copy);
@@ -183,7 +183,7 @@ lives_ok {
 lives_ok {
     print("######## Running RAST annotation fail with bad tax ID ########\n");
     my $params_copy = { %$params };
-    $params_copy->{ncbi_taxon_id} = '1000000000000'; # pretty sure there aren't 1T taxa
+    $params_copy->{ncbi_taxon_id} = 1000000000000; # pretty sure there aren't 1T taxa
     $params_copy->{relation_engine_timestamp_ms} = 1572648527000;
     eval {
         &make_impl_call("RAST_SDK.annotate_genome", $params_copy);

--- a/test/my_assembly_test.pl
+++ b/test/my_assembly_test.pl
@@ -164,7 +164,23 @@ lives_ok {
 	ok(-e $local_path,'File found');
 } "Create a Report";
 
-done_testing(28);
+# Test failing to contact the RE with bad input.
+lives_ok {
+    print("######## Running RAST annotation fail with bad RE input ########\n");
+    my $params_copy = { %$params };
+    $params_copy->{ncbi_taxon_id} = '32'; 
+    $params_copy->{relation_engine_timestamp_ms} = 'Sept 19 2020';  # oops
+    eval {
+        &make_impl_call("RAST_SDK.annotate_genome", $params_copy);
+    };
+    # the error here is a JSON string appended with a file and line number, and so can't be
+    # decoded. Arrg.
+    ok(index($@, "Error contacting Relation Engine: 400 BAD REQUEST") != -1,
+        "Correct error message");
+} "Fail contacting RE";
+
+
+done_testing(30);
 
 my $err = undef;
 if ($@) {

--- a/test/my_assembly_test.pl
+++ b/test/my_assembly_test.pl
@@ -179,8 +179,22 @@ lives_ok {
         "Correct error message");
 } "Fail contacting RE";
 
+# Test sending a non-existant taxon to the RE.
+lives_ok {
+    print("######## Running RAST annotation fail with bad tax ID ########\n");
+    my $params_copy = { %$params };
+    $params_copy->{ncbi_taxon_id} = '1000000000000'; # pretty sure there aren't 1T taxa
+    $params_copy->{relation_engine_timestamp_ms} = 1572648527000;
+    eval {
+        &make_impl_call("RAST_SDK.annotate_genome", $params_copy);
+    };
+    # the error here is a JSON string appended with a file and line number, and so can't be
+    # decoded. Arrg.
+    ok(index($@, "No result from Relation Engine for NCBI taxonomy ID 1000000000000") != -1,
+        "Correct error message");
+} "Fail bad taxon ID";
 
-done_testing(30);
+done_testing(32);
 
 my $err = undef;
 if ($@) {

--- a/ui/narrative/methods/annotate_contigset/spec.json
+++ b/ui/narrative/methods/annotate_contigset/spec.json
@@ -41,7 +41,7 @@
         "query_on_empty_input": 0,
         "result_array_index": 0,
         "path_to_selection_items": ["results"],
-        "selection_id": "scientific_name",
+        "selection_id": "ncbi_taxon_id",
         "description_template": "NCBI Tax ID {{ncbi_taxon_id}}:&nbsp<strong>{{scientific_name}}</strong>",
         "multiselection": false
     }
@@ -288,8 +288,12 @@
           "target_type_transform": "resolved-ref"
         },
         {
+          "narrative_system_variable": "timestamp_epoch_ms",
+          "target_property": "relation_engine_timestamp_ms"
+        },
+        {
           "input_parameter": "scientific_name",
-          "target_property": "scientific_name"
+          "target_property": "ncbi_taxon_id"
         },
         {
           "input_parameter": "domain",

--- a/ui/narrative/methods/annotate_contigsets/spec.json
+++ b/ui/narrative/methods/annotate_contigsets/spec.json
@@ -32,9 +32,9 @@
   }, {
     "id": "scientific_name",
     "optional": true,
-    "advanced": true,
+    "advanced": false,
     "allow_multiple": false,
-    "default_values": ["unknown taxon"],
+    "default_values": [""],
     "field_type": "dynamic_dropdown",
     "dynamic_dropdown_options": {
         "data_source": "custom",

--- a/ui/narrative/methods/annotate_contigsets/spec.json
+++ b/ui/narrative/methods/annotate_contigsets/spec.json
@@ -52,7 +52,7 @@
         "query_on_empty_input": 0,
         "result_array_index": 0,
         "path_to_selection_items": ["results"],
-        "selection_id": "scientific_name",
+        "selection_id": "ncbi_taxon_id",
         "description_template": "NCBI Tax ID {{ncbi_taxon_id}}:&nbsp<strong>{{scientific_name}}</strong>",
         "multiselection": false
     }
@@ -308,8 +308,12 @@
           "target_property": "genome_text"
         },
         {
+          "narrative_system_variable": "timestamp_epoch_ms",
+          "target_property": "relation_engine_timestamp_ms"
+        },
+        {
           "input_parameter": "scientific_name",
-          "target_property": "scientific_name"
+          "target_property": "ncbi_taxon_id"
         },
         {
           "input_parameter": "domain",


### PR DESCRIPTION
Requires https://github.com/kbase/narrative/pull/1536
Passes taxonomy IDs to GFU in the new `taxonomy_assignments` field in the `KBaseGenomes.Genome` spec.

Allows passing a taxon ID to the `annotate_genome/s` methods rather than
a scientific name.

If both are passed, the sci name is ignored.

There is one failing test, but it's been failing for months. See:
https://kbase-jira.atlassian.net/browse/SCT-2285
https://kbase-jira.atlassian.net/browse/SCT-2284