### PR TITLE
Change search_taxa method to the quicker search_species method

### DIFF
--- a/ui/narrative/methods/annotate_contigset/spec.json
+++ b/ui/narrative/methods/annotate_contigset/spec.json
@@ -27,15 +27,13 @@
     "field_type": "dynamic_dropdown",
     "dynamic_dropdown_options": {
         "data_source": "custom",
-        "service_function": "taxonomy_re_api.search_taxa",
+        "service_function": "taxonomy_re_api.search_species",
         "service_version": "dev",
         "service_params": [
             {
                 "search_text": "prefix:{{dynamic_dropdown_input}}",
                 "ns": "ncbi_taxonomy",
-                "ranks": ["species"],
-                "include_strains": true,
-                "limit": 1000
+                "limit": 20
             }
         ],
         "query_on_empty_input": 0,

--- a/ui/narrative/methods/annotate_contigsets/spec.json
+++ b/ui/narrative/methods/annotate_contigsets/spec.json
@@ -38,15 +38,13 @@
     "field_type": "dynamic_dropdown",
     "dynamic_dropdown_options": {
         "data_source": "custom",
-        "service_function": "taxonomy_re_api.search_taxa",
+        "service_function": "taxonomy_re_api.search_species",
         "service_version": "dev",
         "service_params": [
             {
                 "search_text": "prefix:{{dynamic_dropdown_input}}",
                 "ns": "ncbi_taxonomy",
-                "ranks": ["species"],
-                "include_strains": true,
-                "limit": 1000
+                "limit": 20
             }
         ],
         "query_on_empty_input": 0,


### PR DESCRIPTION
This uses a different method in taxonomy_re_api that should be faster for the autocomplete.

Note this is a request to merge into the branch dev-taxon-lookup, not master

I wasn't able to test this.. not sure how without deploying the app