### PR TITLE
More refinement to prevent NoneType error

### DIFF
--- a/lib/RAST_SDK/AnnotationUtils.pm
+++ b/lib/RAST_SDK/AnnotationUtils.pm
@@ -1703,6 +1703,11 @@ sub _fillRequiredFields {
     if (!defined($input_obj->{features})) {
         $input_obj->{features} = [];
     }
+    foreach my $ftr (@{$input_obj->{features}}) {
+        if (!defined($ftr->{cdss})) {
+            $ftr->{cdss} = [];
+        }
+    }
     if (!defined($input_obj->{feature_counts})) {
         $input_obj->{feature_counts} = {
 	        CDS => 0,
@@ -1783,7 +1788,7 @@ sub _reformat_feature_aliases {
     my ($self, $ftr) = @_;
     if (defined($ftr->{aliases}) && @{$ftr->{aliases}})  {
         if (ref($ftr->{aliases}->[0]) !~ /ARRAY/) {
-        # Found some pseudogenes that have wrong structure for aliases
+            # Found some pseudogenes that have wrong structure for aliases
             my $tmp = [];
             for my $key (@{$ftr->{aliases}})  {
                 my @ary = ('alias', $key);
@@ -1871,7 +1876,7 @@ sub _build_ontology_events {
         ontology_terms => $all_onto_terms
     };
     $gn_with_events->{object} = $input_gn;
-
+    #print "Ontology terms:\n".Dumper($all_onto_terms);
     return $gn_with_events;
 }
 
@@ -1930,7 +1935,6 @@ sub _save_genome_with_ontSer {
             append => 0,
             html => 0
         });
-        print "\nOne genome has been saved with ontology service.\n";
         return ({ref => $ref}, $message);
     } catch {
         my $err_msg = "ERROR: Calling anno_ontSer_client.add_annotation_ontology_events failed with error message:$_\n";

--- a/lib/RAST_SDK/AnnotationUtils.pm
+++ b/lib/RAST_SDK/AnnotationUtils.pm
@@ -129,9 +129,13 @@ sub _get_genome_gff_contents {
     if ($is_genome) {
         # generating the gff file directly from genome object ref
         $gff_filename = $self->_write_gff_from_genome($obj);
-        return [] unless (-s $gff_filename);
-        ($gff_contents, $attr_delimiter) = $self->_parse_gff(
+        if (-s $gff_filename) {
+            ($gff_contents, $attr_delimiter) = $self->_parse_gff(
                                                  $gff_filename, $attr_delimiter);
+        } else {
+            print "GFF is empty ";
+            $gff_contents = [];
+        }
     }
     return $gff_contents;
 }
@@ -2124,7 +2128,6 @@ sub _write_gff_from_genome {
     try {
         $gff_result = $gfu->genome_to_gff({"genome_ref" => $genome_ref});
 
-        unless (-s $gff_result->{file_path}) {print "GFF is empty ";}
         return $gff_result->{file_path};
     } catch {
         croak "**_write_gff_from_genome ERROR:\n$_\n";

--- a/lib/RAST_SDK/AnnotationUtils.pm
+++ b/lib/RAST_SDK/AnnotationUtils.pm
@@ -129,6 +129,8 @@ sub _get_genome_gff_contents {
     if ($is_genome) {
         # generating the gff file directly from genome object ref
         $gff_filename = $self->_write_gff_from_genome($obj);
+        my $fsize = -s $gff_filename;
+        print "GFF file at $gff_filename has a size of $fsize";
         if (-s $gff_filename) {
             ($gff_contents, $attr_delimiter) = $self->_parse_gff(
                                                  $gff_filename, $attr_delimiter);
@@ -2127,7 +2129,6 @@ sub _write_gff_from_genome {
     my $gff_result;
     try {
         $gff_result = $gfu->genome_to_gff({"genome_ref" => $genome_ref});
-
         return $gff_result->{file_path};
     } catch {
         croak "**_write_gff_from_genome ERROR:\n$_\n";

--- a/lib/RAST_SDK/AnnotationUtils.pm
+++ b/lib/RAST_SDK/AnnotationUtils.pm
@@ -1781,6 +1781,9 @@ sub _fillRequiredFields {
     if (!defined($input_obj->{warnings})) {
         $input_obj->{warnings} = [];
     }
+    if (!defined($input_obj->{ontology_events})) {
+        $input_obj->{ontology_events} = [];
+    }
     return $input_obj;
 }
 
@@ -1922,6 +1925,7 @@ sub _save_genome_with_ontSer {
     my $anno_ontSer_client = installed_clients::annotation_ontology_apiServiceClient->new(
 	                                        undef, token => $self->{_token});
     try {
+        #print "Input data with Ontology terms sent to add_annotation_ontology_events:\n".Dumper($gn_with_events);
         my $ontSer_output = $anno_ontSer_client->add_annotation_ontology_events($gn_with_events);
         my $ref = $ontSer_output->{output_ref};
 
@@ -1972,6 +1976,9 @@ sub _save_annotation_results {
 
     if (defined($rasted_gn->{genetic_code})) {
         $rasted_gn->{genetic_code} = $rasted_gn->{genetic_code}+0;
+    }
+    if (defined($rasted_gn->{gc_content})) {
+        $rasted_gn->{gc_content} = $rasted_gn->{gc_content}+0;
     }
     ## Saving annotated genome by GFU client
     #$self->_save_genome_with_gfu($rasted_gn, $parameters, $message);

--- a/test/annotation_utils.t
+++ b/test/annotation_utils.t
@@ -1339,6 +1339,7 @@ subtest '_summarize_annotation' => sub {
               $rast_ref2, $final_genome2, $inputgenome2);
     } "_summarize_annotation runs successfully on assembly $obj_asmb";
 };
+=cut
 
 =begin
 # Test _reformat_feature_aliases for RAST annotated objects in prod
@@ -1510,7 +1511,6 @@ subtest '_create_onto_terms' => sub {
     $termSize = keys %$ret_terms;
     ok (!$termSize, "$termSize non_coding_features ontology terms created.");
 };
-=cut
 
 
 # Test _build_ontology_events for RAST annotated objects in prod
@@ -1617,12 +1617,15 @@ subtest '_save_annotation_results' => sub {
     } "_save_annotation_results finished on genome $obj_Ecoli returned as expected";
     ok (exists($save_ret->{ref}), "_save_annotation_results succeeded.");
 
-    # an assembly object
+    # RAST annotation of an assembly object
+    #print "******Before saving, the RASTed genome data:\n".Dumper($final_genome2);
     lives_ok {
         ($save_ret, $out_msg) = $annoutil->_save_annotation_results(
                                             $final_genome2, $rast_ref2);
     } "_save_annotation_results on assembly $obj_asmb returned expected result.";
     ok (exists($save_ret->{ref}), "_save_annotation_results succeeded.");
+    my $saved_anno_data = $annoutil->_fetch_object_data($save_ret->{ref});
+    print "***One OntSer saved RAST annotation object data****\n".Dumper($saved_anno_data);
 };
 
 =begin
@@ -2171,27 +2174,64 @@ subtest 'anno_utils_rast_genome' => sub {
         ok (($rast_ret->{output_genome_ref} =~ m/[^\\w\\|._-]/), "rast_genome returns a VALID ref: $rast_ret->{output_genome_ref}");
     }
 };
-
+=cut
 
 ## testing Impl_rast_genome_assembly using $GEBA_1003_asmb from prod
  # to investigate the extra features
 subtest 'Impl_rast_genome_assembly1' => sub {
+    my $rast_ret = {};
     my $parms = {
         "object_ref" => $GEBA_1003_asmb,
         "output_genome_name" => "rasted_GEBA_1003_asmb",
         "output_workspace" => $ws_name,
         "create_report" => 1
     };
-    my $rast_ret;
+
     lives_ok {
         $rast_ret = $rast_impl->rast_genome_assembly($parms);
-    } 'Impl rast_genome call on $GEBA_1003_asmb returns normally on genome.';
-    # ok ($rast_ret->{output_genome_ref} !~ m/[^\\w\\|._-]/,
+    } "Impl rast_genome call on $GEBA_1003_asmb returns {}.";
     ok ( !defined($rast_ret->{output_genome_ref}),
          "rast_genome_assembly returned an undef object ref." );
+
+    $parms = {
+        "object_ref" => "63171/266/3",  # Ecoli_refseq_assembly
+        "output_genome_name" => "rasted_Ecoli_refseq_assembly",
+        "output_workspace" => $ws_name,
+        "create_report" => 1
+    };
+    lives_ok {
+        $rast_ret = $rast_impl->rast_genome_assembly($parms);
+    } "Impl rast_genome call on $parms->{object_ref} returns {}.";
+    ok ( !defined($rast_ret->{output_genome_ref}),
+         "rast_genome_assembly returned an undef object ref." );
+
+    $parms = {
+        "object_ref" => $obj_Ecoli,  # Ecoli refseq genome
+        "output_genome_name" => "rasted_Ecoli_refseq_genome",
+        "output_workspace" => $ws_name,
+        "create_report" => 1
+    };
+    lives_ok {
+        $rast_ret = $rast_impl->rast_genome_assembly($parms);
+        #print "$parms->{object_ref} rast_genome_assembly returns:\n".Dumper($rast_ret);
+    } "Impl rast_genome_assembly call on $parms->{object_ref} returns $rast_ret->{output_genome_ref}.";
+    ok ($rast_ret->{output_genome_ref}, "success on $parms->{object_ref}");
+
+    $parms = {
+        "object_ref" => $obj_Echinacea,  # Echinacea genome
+        "output_genome_name" => "rasted_Echinacea_genome",
+        "output_workspace" => $ws_name,
+        "create_report" => 1
+    };
+    lives_ok {
+        $rast_ret = $rast_impl->rast_genome_assembly($parms);
+        print "$parms->{object_ref} rast_genome_assembly returns:\n".Dumper($rast_ret);
+    } "Impl rast_genome_assembly call on $parms->{object_ref} returns $rast_ret->{output_genome_ref}.";
+    ok ($rast_ret->{output_genome_ref}, "success on $parms->{object_ref}");
 };
 
 
+=begin
 ## testing Impl_rast_genome_assembly using obj ids from prod ONLY
 subtest 'Impl_rast_genome_assembly2' => sub {
     my $parms = {
@@ -2222,7 +2262,6 @@ subtest 'Impl_rast_genome_assembly2' => sub {
     ok (!defined($rast_ret ->{output_genome_ref}),
         "due to local annotation on assembly with empty features, no rast was run.");
 };
-
 
 ## testing _get_bulk_rast_parameters using obj ids from prod ONLY
 subtest '_get_bulk_rast_parameters' => sub {

--- a/test/annotation_utils.t
+++ b/test/annotation_utils.t
@@ -76,7 +76,8 @@ my $obj3 = "55141/77/1";  # prod KBaseGenomeAnnotations.Assembly
 my $asmb_fasta;
 
 lives_ok {
-    $asmb_fasta = $annoutil->_get_fasta_from_assembly($obj_asmb);
+    #$asmb_fasta = $annoutil->_get_fasta_from_assembly($obj_asmb);
+    $asmb_fasta = $annoutil->_get_fasta_from_assembly($obj1);
 } 'Got FASTA from saved assembly file';
 
 unless ( $asmb_fasta ) {
@@ -352,6 +353,7 @@ subtest '_get_feature_function_lookup' => sub {
 };
 =cut
 
+=begin
 #
 ## Global variables for the annotation process steps to share ##
 #
@@ -1338,6 +1340,7 @@ subtest '_summarize_annotation' => sub {
               $rast_ref2, $final_genome2, $inputgenome2);
     } "_summarize_annotation runs successfully on assembly $obj_asmb";
 };
+=cut
 
 =begin
 # Test _reformat_feature_aliases for RAST annotated objects in prod
@@ -1562,6 +1565,7 @@ subtest '_build_ontology_events' => sub {
 };
 =cut
 
+=begin
 # Test _save_annotation_results with genome/assembly object refs in prod
 subtest '_save_annotation_results' => sub {
     my ($save_ret, $out_msg);
@@ -1624,6 +1628,7 @@ subtest '_save_annotation_results' => sub {
     my $saved_anno_data = $annoutil->_fetch_object_data($save_ret->{ref});
     #print "***One OntSer saved RAST annotation object data****\n".Dumper($saved_anno_data);
 };
+=cut
 
 =begin
 #
@@ -2240,9 +2245,8 @@ subtest 'Impl_rast_genome_assembly1' => sub {
     ok ( !defined($rast_ret->{output_genome_ref}),
          "rast_genome_assembly returned an undef object ref." );
 };
-=cut
 
-=begin
+
 ## testing Impl_rast_genome_assembly using obj ids from prod ONLY
 subtest 'Impl_rast_genome_assembly2' => sub {
     my $parms = {
@@ -2273,7 +2277,79 @@ subtest 'Impl_rast_genome_assembly2' => sub {
     ok (!defined($rast_ret ->{output_genome_ref}),
         "due to local annotation on assembly with empty features, no rast was run.");
 };
+=cut
 
+
+## testing Impl_rast_genome_assembly using obj ids from appdev ONLY
+subtest 'Impl_rast_genome_assembly3' => sub {
+    my $rast_ret = {};
+    my $parms1 = {
+        "object_ref" => "42297/11/1",
+        "output_genome_name" => "rasted_EscherichiaMG1655_asmb",
+        "output_workspace" => $ws_name,
+        "create_report" => 1
+    };
+    lives_ok {
+        $rast_ret = $rast_impl->rast_genome_assembly($parms1);
+    } "Impl rast_genome_assembly call returns normally on genome $parms1->{object_ref}";
+    ok (keys %{ $rast_ret }, "rast_genome_assembly returns:\n".Dumper($rast_ret));
+    ok (!defined($rast_ret->{output_genome_ref}),
+        "rast_genome_assembly did not return a valid ref.");
+    is ($rast_ret->{output_workspace}, $parms1->{output_workspace}, "workspace is correct.");
+    ok (!defined($rast_ret->{report_ref}), "No report created.");
+    ok (!defined($rast_ret->{report_name}), "No report created.");
+
+    my $parms2 = {
+        "object_ref" => "42297/12/1",
+        "output_genome_name" => "rasted_Rhodobacter_genome",
+        "output_workspace" => $ws_name,
+        "create_report" => 1
+    };
+    lives_ok {
+        $rast_ret = $rast_impl->rast_genome_assembly($parms2);
+    } "Impl rast_genome_assembly call returns normally on genome $parms2->{object_ref}";
+    ok (keys %{ $rast_ret }, "rast_genome_assembly returns:\n".Dumper($rast_ret));
+    ok ($rast_ret->{output_genome_ref},
+        "rast_genome_assembly returned a valid ref $rast_ret->{output_genome_ref}");
+    is ($rast_ret->{output_workspace}, $parms2->{output_workspace}, "workspace is correct.");
+    ok (!defined($rast_ret->{report_ref}), "No report created.");
+    ok (!defined($rast_ret->{report_name}), "No report created.");
+
+    my $parms3 = {
+        "object_ref" => "42297/15/1",
+        "output_genome_name" => "rasted_preRasted_Shewanella_genome",
+        "output_workspace" => $ws_name,
+        "create_report" => 1
+    };
+    lives_ok {
+        $rast_ret = $rast_impl->rast_genome_assembly($parms3);
+    } "Impl rast_genome_assembly call returns normally on genome $parms3->{object_ref}";
+    ok (keys %{ $rast_ret }, "rast_genome_assembly returns:\n".Dumper($rast_ret));
+    ok (!defined($rast_ret->{output_genome_ref}),
+        "rast_genome_assembly did not return a valid ref.");
+    is ($rast_ret->{output_workspace}, $parms3->{output_workspace}, "workspace is correct.");
+    ok (!defined($rast_ret->{report_ref}), "No report created.");
+    ok (!defined($rast_ret->{report_name}), "No report created.");
+
+    my $parms4 = {
+        "object_ref" => "42297/19/1",
+        "output_genome_name" => "rasted_preRasted_Rhodobacter_genome",
+        "output_workspace" => $ws_name,
+        "create_report" => 1
+    };
+    lives_ok {
+        $rast_ret = $rast_impl->rast_genome_assembly($parms4);
+    } "Impl rast_genome_assembly call returns normally on genome $parms4->{object_ref}";
+    ok (keys %{ $rast_ret }, "rast_genome_assembly returns:\n".Dumper($rast_ret));
+    ok (!defined($rast_ret->{output_genome_ref}),
+        "rast_genome_assembly did not return a valid ref.");
+    is ($rast_ret->{output_workspace}, $parms4->{output_workspace}, "workspace is correct.");
+    ok (!defined($rast_ret->{report_ref}), "No report created.");
+    ok (!defined($rast_ret->{report_name}), "No report created.");
+};
+
+
+=begin
 ## testing _get_bulk_rast_parameters using obj ids from prod ONLY
 subtest '_get_bulk_rast_parameters' => sub {
     my $parms = {

--- a/test/annotation_utils.t
+++ b/test/annotation_utils.t
@@ -44,8 +44,7 @@ my $rast_impl = RAST_SDK::RAST_SDKImpl->new();
 my $annoutil  = RAST_SDK::AnnotationUtils->new( $config, $ctx );
 
 my $scratch = $config->{ 'scratch' };    #'/kb/module/work/tmp';
-my $rast_genome_dir
-    = $annoutil->_create_rast_subdir( $scratch, "genome_annotation_dir_" );
+my $rast_genome_dir = $annoutil->_create_rast_subdir( $scratch, "genome_annotation_dir_" );
 
 sub get_feature_locations {
     my ($ctgID_hash, $ftr_arr) = @_;
@@ -97,40 +96,40 @@ my $GEBA_1003_asmb_ann = '63171/569/1';
 
 # used for function lookup in report testing
 my $test_ftrs = [{
- 'id' => '10000_1',
- 'protein_translation' => 'VVVLLHGGCCEDMQRGRRESAPDLTLVVYPHALHALDMRLPDRTVLGMRLGFDAHAAADARRQVLDFLTARGVAPPDR*'
- },
- {
- 'function' => 'L-carnitine dehydratase/bile acid-inducible protein F (EC 2.8.3.16)',
- 'quality' => {
- 'hit_count' => 3
- },
- 'annotations' => [
-     [
-     'Function updated to L-carnitine dehydratase/bile acid-inducible protein F (EC 2.8.3.16)',
-     'annotate_proteins_kmer_v1',
-     '1583389302.95393',
-     '6c670c83-2a11-49ff-97bf-b1c3e2121f30'
-     ]
- ],
- 'id' => '10000_2'
- },
- {
- 'id' => '10000_3',
- 'protein_translation' => 'MLAVNEPTVVLASAETKSLGPVVTGDRLETEAEVERTDGRKRWVKVTVRRAGAPVMEGQFLAVVPDRHILDAKDARR*'
- },
- {
- 'id' => '10000_madeup',
- 'function' => 'completely fake function',
- 'annotations' => [
-     [
-     'completely fake function',
-     'annotate_madeup_source',
-     '1583389302.95394',
-     '6c670c83-2a11-49ff-97bf-b1c3e2121f33'
-     ]
- ],
- }];
+        'id' => '10000_1',
+        'protein_translation' => 'VVVLLHGGCCEDMQRGRRESAPDLTLVVYPHALHALDMRLPDRTVLGMRLGFDAHAAADARRQVLDFLTARGVAPPDR*'
+    },
+    {
+        'function' => 'L-carnitine dehydratase/bile acid-inducible protein F (EC 2.8.3.16)',
+        'quality' => {
+            'hit_count' => 3
+        },
+        'annotations' => [
+            [
+                'Function updated to L-carnitine dehydratase/bile acid-inducible protein F (EC 2.8.3.16)',
+                'annotate_proteins_kmer_v1',
+                '1583389302.95393',
+                '6c670c83-2a11-49ff-97bf-b1c3e2121f30'
+            ]
+        ],
+        'id' => '10000_2'
+    },
+    {
+        'id' => '10000_3',
+        'protein_translation' => 'MLAVNEPTVVLASAETKSLGPVVTGDRLETEAEVERTDGRKRWVKVTVRRAGAPVMEGQFLAVVPDRHILDAKDARR*'
+    },
+    {
+        'id' => '10000_madeup',
+        'function' => 'completely fake function',
+        'annotations' => [
+            [
+                'completely fake function',
+                'annotate_madeup_source',
+                '1583389302.95394',
+                '6c670c83-2a11-49ff-97bf-b1c3e2121f33'
+            ]
+        ],
+    }];
 
 =begin
 # test the _map_location_contigIDs function
@@ -353,7 +352,6 @@ subtest '_get_feature_function_lookup' => sub {
 };
 =cut
 
-=begin
 #
 ## Global variables for the annotation process steps to share ##
 #
@@ -1340,7 +1338,6 @@ subtest '_summarize_annotation' => sub {
               $rast_ref2, $final_genome2, $inputgenome2);
     } "_summarize_annotation runs successfully on assembly $obj_asmb";
 };
-=cut
 
 =begin
 # Test _reformat_feature_aliases for RAST annotated objects in prod
@@ -1563,6 +1560,7 @@ subtest '_build_ontology_events' => sub {
     $evts = $ret_gn->{events};
     ok( $evts, "_build_ontology_events returns events.");
 };
+=cut
 
 # Test _save_annotation_results with genome/assembly object refs in prod
 subtest '_save_annotation_results' => sub {
@@ -1594,10 +1592,8 @@ subtest '_save_annotation_results' => sub {
     #my $saved_anno_data = $annoutil->_fetch_object_data($save_ret->{ref});
     #print "***One OntSer saved RAST annotation object data****\n".Dumper($saved_anno_data);
 
-    $nc_ftr_count = @{$final_genome01->{non_coding_features}};
-    print "\n********For case $obj_refseq_GCF*********\n".
-          "AFTER _save_annotation_results there are $nc_ftr_count non_coding features.\n";
     # a genome object in workspace #65386
+    $nc_ftr_count = @{$final_genome01->{non_coding_features}};
     lives_ok {
         ($save_ret, $out_msg) = $annoutil->_save_annotation_results(
                                             $final_genome01, $rast_ref01);
@@ -1626,9 +1622,8 @@ subtest '_save_annotation_results' => sub {
     } "_save_annotation_results on assembly $obj_asmb returned expected result.";
     ok (exists($save_ret->{ref}), "_save_annotation_results succeeded.");
     my $saved_anno_data = $annoutil->_fetch_object_data($save_ret->{ref});
-    print "***One OntSer saved RAST annotation object data****\n".Dumper($saved_anno_data);
+    #print "***One OntSer saved RAST annotation object data****\n".Dumper($saved_anno_data);
 };
-=cut
 
 =begin
 #
@@ -2178,6 +2173,7 @@ subtest 'anno_utils_rast_genome' => sub {
 };
 =cut
 
+=begin
 ## testing Impl_rast_genome_assembly using $GEBA_1003_asmb from prod
  # to investigate the extra features
 subtest 'Impl_rast_genome_assembly1' => sub {
@@ -2244,7 +2240,7 @@ subtest 'Impl_rast_genome_assembly1' => sub {
     ok ( !defined($rast_ret->{output_genome_ref}),
          "rast_genome_assembly returned an undef object ref." );
 };
-
+=cut
 
 =begin
 ## testing Impl_rast_genome_assembly using obj ids from prod ONLY

--- a/test/annotation_utils.t
+++ b/test/annotation_utils.t
@@ -353,6 +353,7 @@ subtest '_get_feature_function_lookup' => sub {
 };
 =cut
 
+=begin
 #
 ## Global variables for the annotation process steps to share ##
 #
@@ -1627,6 +1628,7 @@ subtest '_save_annotation_results' => sub {
     my $saved_anno_data = $annoutil->_fetch_object_data($save_ret->{ref});
     print "***One OntSer saved RAST annotation object data****\n".Dumper($saved_anno_data);
 };
+=cut
 
 =begin
 #
@@ -2189,7 +2191,7 @@ subtest 'Impl_rast_genome_assembly1' => sub {
 
     lives_ok {
         $rast_ret = $rast_impl->rast_genome_assembly($parms);
-    } "Impl rast_genome call on $GEBA_1003_asmb returns {}.";
+    } "Impl rast_genome call on $GEBA_1003_asmb returns.";
     ok ( !defined($rast_ret->{output_genome_ref}),
          "rast_genome_assembly returned an undef object ref." );
 
@@ -2201,7 +2203,7 @@ subtest 'Impl_rast_genome_assembly1' => sub {
     };
     lives_ok {
         $rast_ret = $rast_impl->rast_genome_assembly($parms);
-    } "Impl rast_genome call on $parms->{object_ref} returns {}.";
+    } "Impl rast_genome call on $parms->{object_ref} returns.";
     ok ( !defined($rast_ret->{output_genome_ref}),
          "rast_genome_assembly returned an undef object ref." );
 
@@ -2213,8 +2215,8 @@ subtest 'Impl_rast_genome_assembly1' => sub {
     };
     lives_ok {
         $rast_ret = $rast_impl->rast_genome_assembly($parms);
-        #print "$parms->{object_ref} rast_genome_assembly returns:\n".Dumper($rast_ret);
-    } "Impl rast_genome_assembly call on $parms->{object_ref} returns $rast_ret->{output_genome_ref}.";
+        print "$parms->{object_ref} rast_genome_assembly returns:\n".Dumper($rast_ret);
+    } "Impl rast_genome_assembly call on $parms->{object_ref} returns.";
     ok ($rast_ret->{output_genome_ref}, "success on $parms->{object_ref}");
 
     $parms = {
@@ -2226,8 +2228,21 @@ subtest 'Impl_rast_genome_assembly1' => sub {
     lives_ok {
         $rast_ret = $rast_impl->rast_genome_assembly($parms);
         print "$parms->{object_ref} rast_genome_assembly returns:\n".Dumper($rast_ret);
-    } "Impl rast_genome_assembly call on $parms->{object_ref} returns $rast_ret->{output_genome_ref}.";
+    } "Impl rast_genome_assembly call on $parms->{object_ref} returns.";
     ok ($rast_ret->{output_genome_ref}, "success on $parms->{object_ref}");
+
+    $parms = {
+        "object_ref" => "63171/528/1",  # test_checkAll_Ecoli_Sept23
+        "output_genome_name" => "rasted_test_chkAll",
+        "output_workspace" => $ws_name,
+        "create_report" => 1
+    };
+    lives_ok {
+        $rast_ret = $rast_impl->rast_genome_assembly($parms);
+        print "$parms->{object_ref} rast_genome_assembly returns:\n".Dumper($rast_ret);
+    } "Impl rast_genome_assembly call on $parms->{object_ref} returns.";
+    ok ( !defined($rast_ret->{output_genome_ref}),
+         "rast_genome_assembly returned an undef object ref." );
 };
 
 


### PR DESCRIPTION
Adding more required keys to the input: 'cdss' for the features substructure and 'ontology_events' to (hopefully) avoid the "object of type 'NoneType' has no len()" error from the annotation_ontology_api service call.